### PR TITLE
:wrench: change homepage to d4l.io

### DIFF
--- a/package.json
+++ b/package.json
@@ -113,5 +113,5 @@
   "bugs": {
     "url": "https://github.com/d4l-data4life/js-sdk/issues"
   },
-  "homepage": "https://github.com/d4l-data4life/js-sdk#readme"
+  "homepage": "https://www.d4l.io/"
 }


### PR DESCRIPTION
### Summary of the issue
As we have our great dev page d4l.io we should also proudly announce this in the package.json.