### PR TITLE
:construction_worker: run tests on PR

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,26 @@
+name: Run tests on PR
+on:
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - name: Add js-crypto ssh key
+        uses: webfactory/ssh-agent@v0.2.0
+        with:
+          ssh-private-key: ${{ secrets.HC_CRYPTO_JS_DEPLOY_KEY }}
+
+
+      - uses: actions/setup-node@v1
+        with:
+          node-version: '12.x'
+          registry-url: https://registry.npmjs.org/
+
+      - name: Test
+        run: |
+          npm ci
+          NODE_ENV=test npm run test


### PR DESCRIPTION
### Summary of the issue
With moving the Repository we got rid of the check that runs the tests on PR. This PR about reenabling it.

### How to reproduce your bugfix or feature
This PR should show that it works.
