### PR TITLE
Glumli/reset partner

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,6 +3,9 @@ on:
   pull_request:
     branches:
       - master
+  push:
+    branches:
+      - master
 
 jobs:
   test:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@d4l/js-sdk",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "D4L": {
     "data_model_version": 1
   },

--- a/src/d4l.js
+++ b/src/d4l.js
@@ -152,7 +152,7 @@ export const D4LSDK = {
    * resets the SDK
    */
   reset() {
-    taggingUtils.clientId = null;
+    taggingUtils.reset();
     d4lRequest.reset();
     userService.resetUser();
   },

--- a/src/lib/taggingUtils.ts
+++ b/src/lib/taggingUtils.ts
@@ -1,6 +1,7 @@
 import isString from 'lodash/isString';
 import stringUtils from './stringUtils';
 import { CURRENT_FHIR_VERSION } from '../services/fhirService';
+import SetupError, { NOT_SETUP } from './errors/SetupError';
 
 const TAG_DELIMITER = '=';
 
@@ -17,23 +18,34 @@ export const tagKeys: { [key: string]: string } = {
 const taggingUtils = {
   partnerId: null,
 
-  setPartnerId(partnerId) {
+  reset() {
+    this.partnerId = null;
+  },
+
+  setPartnerId(partnerId: string | null): void {
     this.partnerId = partnerId;
   },
 
-  generateCreationTag() {
-    return this.buildTag(tagKeys.partner, this.partnerId);
+  getPartnertId(): string {
+    if (!this.partnerId) {
+      throw new SetupError(NOT_SETUP);
+    }
+    return this.partnerId;
   },
 
-  generateUpdateTag() {
-    return this.buildTag(tagKeys.updatedByPartner, this.partnerId);
+  generateCreationTag(): string {
+    return this.buildTag(tagKeys.partner, this.getPartnertId());
   },
 
-  generateFhirVersionTag() {
+  generateUpdateTag(): string {
+    return this.buildTag(tagKeys.updatedByPartner, this.getPartnertId());
+  },
+
+  generateFhirVersionTag(): string {
     return this.buildTag(tagKeys.fhirVersion, CURRENT_FHIR_VERSION);
   },
 
-  generateTagsFromFhir(fhirObject: any) {
+  generateTagsFromFhir(fhirObject: Record<string, any>): string[] {
     const tagObject: any = {};
     if (fhirObject.resourceType) {
       tagObject[tagKeys.resourceType] = fhirObject.resourceType;

--- a/test/d4lTest.js
+++ b/test/d4lTest.js
@@ -276,4 +276,30 @@ describe('D4L', () => {
       config.environmentConfig = {};
     });
   });
+
+  describe('reset', () => {
+    it('resets the state of the SDK', () => {
+      taggingUtils.partnerId = 'partnerId';
+      d4lRequest.currentUserId = 'currentUserId';
+      d4lRequest.currentUserLanguage = 'currentUserLanguage';
+      d4lRequest.masterAccessToken = 'masterAccessToken';
+      d4lRequest.accessTokens = { userId: 'accessToken' };
+      userService.users = { userId: {} };
+      userService.currentUserId = 'currentUserId';
+      userService.currentAppId = 'partnerId#web';
+      userService.commonKeys = { userId: {} };
+
+      D4LSDK.reset();
+
+      expect(taggingUtils.partnerId).to.equal(null);
+      expect(d4lRequest.currentUserId).to.equal(null);
+      expect(d4lRequest.currentUserLanguage).to.equal(null);
+      expect(d4lRequest.masterAccessToken).to.equal(null);
+      expect(d4lRequest.accessTokens).to.deep.equal({});
+      expect(userService.users).to.deep.equal({});
+      expect(userService.currentUserId).to.equal(null);
+      expect(userService.currentAppId).to.equal(null);
+      expect(userService.commonKeys).to.deep.equal({});
+    });
+  });
 });

--- a/test/lib/taggingUtilsTest.js
+++ b/test/lib/taggingUtilsTest.js
@@ -45,7 +45,13 @@ describe('taggingUtils', () => {
     },
   };
 
-  taggingUtils.setPartnerId(testVariables.partnerId);
+  beforeEach(() => {
+    taggingUtils.setPartnerId(testVariables.partnerId);
+  });
+
+  afterEach(() => {
+    taggingUtils.reset();
+  });
 
   describe('generateTagsFromFhir', () => {
     it('verifies that correct tag values are generated', () => {

--- a/test/services/recordServiceTest.js
+++ b/test/services/recordServiceTest.js
@@ -141,8 +141,8 @@ describe('services/recordService', () => {
       },
       '../lib/taggingUtils': {
         default: {
-          clientId: testVariables.clientId,
           ...taggingUtils,
+          partnerId: testVariables.partnerId,
         },
       },
     }).default;
@@ -151,12 +151,26 @@ describe('services/recordService', () => {
     global.__DATA_MODEL_VERSION__ = testVariables.dataModelVersion;
   });
 
+  afterEach(() => {
+    validateStub.reset();
+    downloadRecordStub.reset();
+    searchRecordsStub.reset();
+    updateRecordStub.reset();
+    getRecordsCountStub.reset();
+    createRecordStub.reset();
+    deleteRecordStub.reset();
+
+    taggingUtils.reset();
+  });
+
   describe('createRecord', () => {
     it('should resolve when called with userId and correct fhirResource', done => {
+      taggingUtils.setPartnerId(testVariables.partnerId);
       const tags = [
         taggingUtils.generateCreationTag(),
         ...taggingUtils.generateTagsFromFhir(fhirResources.documentReference),
       ];
+
       recordService
         .createRecord(testVariables.userId, {
           fhirResource: fhirResources.documentReference,
@@ -258,6 +272,7 @@ describe('services/recordService', () => {
     });
 
     it('should pass the right custom tags corresponding to the annotations passed', done => {
+      taggingUtils.setPartnerId(testVariables.partnerId);
       const tags = [
         ...taggingUtils.generateCustomTags(documentResources.annotations),
         taggingUtils.generateUpdateTag(),
@@ -385,15 +400,5 @@ describe('services/recordService', () => {
         })
         .catch(done);
     });
-  });
-
-  afterEach(() => {
-    validateStub.reset();
-    downloadRecordStub.reset();
-    searchRecordsStub.reset();
-    updateRecordStub.reset();
-    getRecordsCountStub.reset();
-    createRecordStub.reset();
-    deleteRecordStub.reset();
   });
 });


### PR DESCRIPTION
### Summary of the issue
In D4LSDK.reset we were resetting the clientId which is actually never set. Instead we need to reset the partnerId. This is done in this PR.

Also this PR makes tests run on the master to make sure that everything is runnning after merge.

### Due diligence checklist
- [x] Updated version in package.json if applicable.
- [x] Added/updated tests.