### PR TITLE
✨ ⬆️ HUB-901 add 'appData' support - CRUD methods for piping non-Fhir data through the SDK

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@d4l/js-sdk",
-  "version": "2.2.3",
+  "version": "2.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@d4l/js-sdk",
-  "version": "2.2.3",
+  "version": "2.3.0",
   "D4L": {
     "data_model_version": 1
   },

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -24,7 +24,7 @@ const config = {
   userUrl(ownerId) {
     return `${this.apiUrl()}/users/${ownerId}`;
   },
-  rateLimit: 100, // 200, but divide by 2 to account for pre-flight requests
+  rateLimit: 50, // 100, but divide by 2 to account for pre-flight requests
   userInfoPollInterval: 5 * 60, // check for new common keys every 5 minutes
 };
 

--- a/src/d4l.js
+++ b/src/d4l.js
@@ -37,6 +37,7 @@ import {
 import { throttle } from './lib/requestUtils';
 import Attachment from './lib/models/fhir/Attachment';
 import ValidationError from './lib/errors/ValidationError';
+import appDataService from './services/appDataService';
 
 export const D4LSDK = {
   getCurrentUserId: userService.getCurrentUserId.bind(userService),
@@ -44,6 +45,12 @@ export const D4LSDK = {
   grantPermission: userService.grantPermission.bind(userService),
   getReceivedPermissions: userService.getReceivedPermissions.bind(userService),
   setCurrentUserLanguage: userService.setCurrentUserLanguage.bind(userService),
+
+  createAppData: appDataService.createAppData.bind(appDataService),
+  fetchAppData: appDataService.fetchAppData.bind(appDataService),
+  updateAppData: appDataService.updateAppData.bind(appDataService),
+  deleteAppData: appDataService.deleteAppData.bind(appDataService),
+  fetchAllAppData: appDataService.fetchAllAppData.bind(appDataService),
 
   createResource: fhirService.createResource.bind(fhirService),
   fetchResource: fhirService.fetchResource.bind(fhirService),

--- a/src/lib/taggingUtils.ts
+++ b/src/lib/taggingUtils.ts
@@ -10,6 +10,7 @@ const ANNOTATION_LABEL = 'custom';
 // all the values will be lowercased by the API
 export const tagKeys: { [key: string]: string } = {
   fhirVersion: 'fhirVersion',
+  flag: 'flag',
   partner: 'partner',
   resourceType: 'resourceType',
   updatedByPartner: 'updatedByPartner',
@@ -26,7 +27,7 @@ const taggingUtils = {
     this.partnerId = partnerId;
   },
 
-  getPartnertId(): string {
+  getPartnerId(): string {
     if (!this.partnerId) {
       throw new SetupError(NOT_SETUP);
     }
@@ -34,11 +35,15 @@ const taggingUtils = {
   },
 
   generateCreationTag(): string {
-    return this.buildTag(tagKeys.partner, this.getPartnertId());
+    return this.buildTag(tagKeys.partner, this.getPartnerId());
   },
 
   generateUpdateTag(): string {
-    return this.buildTag(tagKeys.updatedByPartner, this.getPartnertId());
+    return this.buildTag(tagKeys.updatedByPartner, this.getPartnerId());
+  },
+
+  generateAppDataFlagTag(): string {
+    return this.buildTag(tagKeys.flag, 'appdata');
   },
 
   generateFhirVersionTag(): string {

--- a/src/lib/taggingUtils.ts
+++ b/src/lib/taggingUtils.ts
@@ -16,6 +16,11 @@ export const tagKeys: { [key: string]: string } = {
   updatedByPartner: 'updatedByPartner',
 };
 
+// all the values will be lowercased by the API
+export const flagKeys: { [key: string]: string } = {
+  appData: 'appData',
+};
+
 const taggingUtils = {
   partnerId: null,
 
@@ -43,7 +48,7 @@ const taggingUtils = {
   },
 
   generateAppDataFlagTag(): string {
-    return this.buildTag(tagKeys.flag, 'appdata');
+    return this.buildTag(tagKeys.flag, flagKeys.appData);
   },
 
   generateFhirVersionTag(): string {

--- a/src/services/appDataService.ts
+++ b/src/services/appDataService.ts
@@ -1,0 +1,112 @@
+import taggingUtils, { tagKeys } from '../lib/taggingUtils';
+import documentRoutes from '../routes/documentRoutes';
+import recordService from './recordService';
+import { prepareSearchParameters } from './fhirService';
+
+export interface DecryptedAppData {
+  id?: string;
+  data: any;
+  tags?: string[];
+  customCreationDate?: Date;
+  updatedDate?: Date;
+  commonKeyId?: string;
+}
+
+interface IRecord {
+  id?: string;
+  fhirResource: fhir.DomainResource;
+  annotations?: string[];
+  customCreationDate?: Date;
+  updatedDate?: Date;
+  partner?: string;
+}
+interface IFetchResponse {
+  totalCount: number;
+  records: IRecord[];
+}
+
+const appDataService = {
+  createAppData(
+    ownerId: string,
+    data: any,
+    date: Date = new Date(),
+    annotations: string[] = []
+  ): Promise<any> {
+    return (
+      recordService
+        .uploadRecord(
+          ownerId,
+          {
+            data,
+            customCreationDate: date,
+            tags: [
+              ...new Set([
+                ...taggingUtils.generateCustomTags(annotations),
+                taggingUtils.generateAppDataFlagTag(),
+              ]),
+            ],
+          },
+          documentRoutes.createRecord
+        )
+        // @ts-ignore
+        .then(convertToExposedAppData)
+        .catch(error => {
+          // eslint-disable-next-line no-console
+          console.warn(error);
+          return Promise.reject(new Error('Creating the AppData Entity failed'));
+        })
+    );
+  },
+
+  updateAppData(
+    ownerId: string,
+    data: any,
+    id: string,
+    date,
+    annotations: string[] = []
+  ): Promise<any> {
+    return recordService
+      .updateRecord(ownerId, {
+        data,
+        id,
+        tags: [
+          ...new Set([
+            ...taggingUtils.generateCustomTags(annotations),
+            taggingUtils.generateAppDataFlagTag(),
+          ]),
+        ],
+        customCreationDate: date,
+      })
+      .then(convertToExposedAppData);
+  },
+
+  fetchAppData(ownerId: string, appDataId: string): Promise<DecryptedAppData> {
+    return recordService.downloadRecord(ownerId, appDataId).then(convertToExposedAppData);
+  },
+
+  deleteAppData(ownerId: string, resourceId: string): Promise<void> {
+    return recordService.deleteRecord(ownerId, resourceId);
+  },
+
+  fetchAllAppData(ownerId: string): Promise<IFetchResponse> {
+    const parameters = prepareSearchParameters({
+      tags: [`${tagKeys.flag}=appdata`],
+    });
+
+    return recordService.searchRecords(ownerId, parameters).then(result => ({
+      records: result.records.map(convertToExposedAppData),
+      totalCount: result.totalCount,
+    }));
+  },
+};
+
+const convertToExposedAppData = (decryptedAppData: DecryptedAppData) => ({
+  annotations: taggingUtils.getAnnotations(decryptedAppData.tags),
+  customCreationDate: decryptedAppData.customCreationDate,
+  data: decryptedAppData.data,
+  id: decryptedAppData.id,
+  partner: taggingUtils.getTagValueFromList(decryptedAppData.tags, tagKeys.partner),
+  updatedDate: decryptedAppData.updatedDate,
+});
+
+export default appDataService;

--- a/src/services/fhirService.ts
+++ b/src/services/fhirService.ts
@@ -73,9 +73,18 @@ interface IRecord {
   updatedDate?: Date;
   partner?: string;
 }
+
+interface AppData {
+  id?: string;
+  data: any;
+  annotations?: string[];
+  customCreationDate?: Date;
+  updatedDate?: Date;
+  partner?: string;
+}
 interface IFetchResponse {
   totalCount: number;
-  records: IRecord[];
+  records: IRecord[] | AppData[];
 }
 
 type IAttachment = {

--- a/test/services/appDataServiceTest.js
+++ b/test/services/appDataServiceTest.js
@@ -1,0 +1,172 @@
+/* eslint-env mocha */
+/* eslint-disable no-unused-expressions */
+/* eslint-disable max-nested-callbacks */
+import 'babel-polyfill';
+import chai from 'chai';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+import testVariables from '../testUtils/testVariables';
+import recordService from '../../src/services/recordService';
+import appDataService from '../../src/services/appDataService';
+
+chai.use(sinonChai);
+
+const { expect } = chai;
+
+describe('appDataService', () => {
+  let createRecordStub;
+  let uploadRecordStub;
+  let deleteRecordStub;
+  let updateRecordStub;
+  let downloadRecordStub;
+  let searchRecordsStub;
+
+  const userId = 'user_id';
+  const appDataId = 'appdata_id';
+
+  const decryptedAppData = {
+    id: appDataId,
+    customCreationDate: '2017-09-19',
+    user_id: userId,
+    data: 'I can even be a string',
+    tags: ['tag1', 'tag2', testVariables.secondTag],
+    version: 1,
+    status: 'Active',
+    updatedDate: '2017-09-19T09:29:48.278',
+  };
+
+  const appData = {
+    id: appDataId,
+    customCreationDate: '2017-09-19',
+    data: 'I can even be a string',
+    updatedDate: '2017-09-19T09:29:48.278',
+    annotations: [],
+    partner: '1',
+  };
+
+  beforeEach(() => {
+    createRecordStub = sinon
+      .stub(recordService, 'createRecord')
+      .returns(Promise.resolve(decryptedAppData));
+    uploadRecordStub = sinon
+      .stub(recordService, 'uploadRecord')
+      .returns(Promise.resolve(decryptedAppData));
+    deleteRecordStub = sinon.stub(recordService, 'deleteRecord').returns(Promise.resolve());
+    updateRecordStub = sinon
+      .stub(recordService, 'updateRecord')
+      .returns(Promise.resolve(decryptedAppData));
+    downloadRecordStub = sinon
+      .stub(recordService, 'downloadRecord')
+      // eslint-disable-next-line prefer-promise-reject-errors
+      .returns(Promise.reject('error'));
+    downloadRecordStub.withArgs(userId, appDataId).returns(Promise.resolve(decryptedAppData));
+
+    searchRecordsStub = sinon.stub(recordService, 'searchRecords').returns(
+      Promise.resolve({
+        totalCount: 1,
+        records: [decryptedAppData],
+      })
+    );
+  });
+
+  describe('fetchAppData', () => {
+    it('should fetch an AppData entity', done => {
+      appDataService
+        .fetchAppData(userId, appDataId)
+        .then(result => {
+          expect(downloadRecordStub).to.be.calledWith(userId, appDataId);
+          expect(downloadRecordStub).to.be.calledOnce;
+          expect(result).to.be.defined;
+        })
+        .then(done)
+        .catch(done);
+    });
+  });
+
+  describe('createAppData', () => {
+    it('should create an AppData entity with valid input', done => {
+      const appDataEntity = 'I can even be a string';
+      appDataService
+        .createAppData(userId, appDataEntity)
+        .then(res => {
+          expect(uploadRecordStub).to.be.calledWith(userId);
+          const { args: uploadRecordArgs } = uploadRecordStub.getCall(0);
+          expect(JSON.stringify(uploadRecordArgs)).to.contain('flag=appdata');
+          expect(uploadRecordStub).to.be.calledOnce;
+          expect(res).to.deep.equal(appData);
+          done();
+        })
+        .catch(done);
+    });
+  });
+
+  describe('updateAppData', () => {
+    it('should update an AppData entity correctly', done => {
+      const appDataEntity = Object.assign({ sampleKey: 'SampleValue' });
+      const customCreationDate = new Date();
+      appDataService
+        .updateAppData(userId, appDataEntity, 'id', customCreationDate)
+        .then(res => {
+          expect(updateRecordStub).to.be.calledOnce;
+          expect(updateRecordStub).to.be.calledWith(userId, {
+            id: 'id',
+            data: appDataEntity,
+            tags: ['flag=appdata'],
+            customCreationDate,
+          });
+          expect(res).to.deep.equal(appData);
+          done();
+        })
+        .catch(done);
+    });
+  });
+
+  describe('fetchAppData', () => {
+    it('should fetch an AppData entity correctly', done => {
+      appDataService
+        .fetchAppData(userId, appDataId)
+        .then(res => {
+          expect(downloadRecordStub).to.be.calledWith(userId, appDataId);
+          expect(downloadRecordStub).to.be.calledOnce;
+          expect(res).to.be.defined;
+          done();
+        })
+        .catch(done);
+    });
+  });
+
+  describe('fetchAllAppData', () => {
+    it('should fetch all AppData entities by flag', done => {
+      appDataService
+        .fetchAllAppData(userId)
+        .then(() => {
+          expect(searchRecordsStub).to.be.calledWith(testVariables.userId, {
+            tags: ['flag=appdata'],
+          });
+          done();
+        })
+        .catch(done);
+    });
+  });
+
+  describe('deleteAppData', () => {
+    it('should delete the AppData entities by id', done => {
+      appDataService
+        .deleteAppData(userId, appDataId)
+        .then(() => {
+          expect(deleteRecordStub).to.be.calledWith(testVariables.userId, appDataId);
+          done();
+        })
+        .catch(done);
+    });
+  });
+
+  afterEach(() => {
+    createRecordStub.restore();
+    uploadRecordStub.restore();
+    deleteRecordStub.restore();
+    updateRecordStub.restore();
+    downloadRecordStub.restore();
+    searchRecordsStub.restore();
+  });
+});

--- a/test/services/fhirServiceTest.js
+++ b/test/services/fhirServiceTest.js
@@ -636,9 +636,9 @@ describe('fhirService', () => {
 
   describe('createResource', () => {
     it('should create resource with a valid input', done => {
-      const hcResource = { resourceType: 'CarePlan', id: 'record_id' };
+      const d4lResource = { resourceType: 'CarePlan', id: 'record_id' };
       fhirService
-        .createResource(userId, hcResource)
+        .createResource(userId, d4lResource)
         .then(res => {
           expect(createRecordStub).to.be.calledWith(userId);
           const { args } = createRecordStub.getCall(0);
@@ -670,7 +670,7 @@ describe('fhirService', () => {
 
   describe('updateResource', () => {
     it('should update a resource correctly', done => {
-      const hcResource = Object.assign(
+      const d4lResource = Object.assign(
         {
           id: testVariables.recordId,
         },
@@ -678,12 +678,12 @@ describe('fhirService', () => {
       );
       const customCreationDate = new Date();
       fhirService
-        .updateResource(userId, hcResource, customCreationDate)
+        .updateResource(userId, d4lResource, customCreationDate)
         .then(res => {
           expect(updateRecordStub).to.be.calledOnce;
           expect(updateRecordStub).to.be.calledWith(userId, {
-            id: hcResource.id,
-            fhirResource: hcResource,
+            id: d4lResource.id,
+            fhirResource: d4lResource,
             tags: [],
             attachmentKey: undefined,
             customCreationDate,
@@ -695,10 +695,10 @@ describe('fhirService', () => {
     });
 
     it('should reject a resource without an id', done => {
-      const hcResource = Object.assign({}, fhirResources.carePlan);
-      delete hcResource.id;
+      const d4lResource = Object.assign({}, fhirResources.carePlan);
+      delete d4lResource.id;
       fhirService
-        .updateResource(userId, hcResource)
+        .updateResource(userId, d4lResource)
         .catch(err => {
           expect(err).to.not.be.null;
           expect(updateRecordStub).to.not.be.called;
@@ -748,7 +748,6 @@ describe('fhirService', () => {
           expect(searchRecordsStub).to.be.calledWith(testVariables.userId, {
             tags: ['resourcetype=documentreference'],
           });
-          expect(parameters.resourceType).to.equal('documentReference');
           done();
         })
         .catch(done);


### PR DESCRIPTION
### Summary of the issue
This adds support for storing any form of data in the SDK. This data will not be checked at all and just packaged in the record metadata, encrypted and sent to the backend. It is tagged "flag=appdata", which is also used for the fetch operations for it.

Possible todo: avoid accidental downloading of appdata when calling the `fetchResources` function without any resourceType functions. Possbility is to detect a case and then Promise.all all supported version tags (appdata won't have any) or supported fhir resources (appdata won't have any).

https://gesundheitscloud.atlassian.net/browse/HUB-901

### How to reproduce your bugfix or feature
Describe how to inspect and verify your changes.

### Due diligence checklist
- [x] Updated version in package.json if applicable.
- [x] Added/updated tests.
- [ ] Add documentation
- [x] If this change affects SDK consumers: communicate changes.

