### PR TITLE
🐛 Encrypt exclude_tags parameter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@d4l/js-sdk",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@d4l/js-sdk",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "D4L": {
     "data_model_version": 1
   },

--- a/src/services/fhirService.ts
+++ b/src/services/fhirService.ts
@@ -389,8 +389,10 @@ export const prepareSearchParameters = (params: IParams) => {
   }
 
   if (params.exclude_flags) {
-    parameters.exclude_tags = [...new Set([...(params.exclude_tags || []), ...params.exclude_flags])];
-    delete parameters.exclude_flags
+    parameters.exclude_tags = [
+      ...new Set([...(params.exclude_tags || []), ...params.exclude_flags]),
+    ];
+    delete parameters.exclude_flags;
   }
 
   return parameters;

--- a/src/services/fhirService.ts
+++ b/src/services/fhirService.ts
@@ -382,8 +382,8 @@ export const prepareSearchParameters = (params: IParams) => {
   }
 
   if (params.exclude_tags) {
-    const excludeTags = taggingUtils.generateCustomTags(params.exclude_tags)
-    parameters.exclude_tags = excludeTags
+    const excludeTags = taggingUtils.generateCustomTags(params.exclude_tags);
+    parameters.exclude_tags = excludeTags;
   }
 
   return parameters;

--- a/src/services/fhirService.ts
+++ b/src/services/fhirService.ts
@@ -390,7 +390,7 @@ export const prepareSearchParameters = (params: IParams) => {
 
   if (params.exclude_flags) {
     parameters.exclude_tags = [
-      ...new Set([...(params.exclude_tags || []), ...params.exclude_flags]),
+      ...new Set([...(parameters.exclude_tags || []), ...params.exclude_flags]),
     ];
     delete parameters.exclude_flags;
   }

--- a/src/services/fhirService.ts
+++ b/src/services/fhirService.ts
@@ -55,6 +55,7 @@ interface IParams {
   end_date?: string;
   tags?: string[];
   exclude_tags?: string[];
+  exclude_flags?: string[];
   annotations?: string[];
   resourceType?: string;
   partner?: string;
@@ -102,6 +103,7 @@ const SUPPORTED_PARAMS = [
   'end_date',
   'tags',
   'exclude_tags',
+  'exclude_flags',
   'annotations',
   'resourceType',
   'partner',
@@ -386,6 +388,11 @@ export const prepareSearchParameters = (params: IParams) => {
     parameters.exclude_tags = excludeTags;
   }
 
+  if (params.exclude_flags) {
+    parameters.exclude_tags = [...new Set([...(params.exclude_tags || []), ...params.exclude_flags])];
+    delete parameters.exclude_flags
+  }
+
   return parameters;
 };
 
@@ -617,9 +624,7 @@ const fhirService = {
   countResources(ownerId: string, params: IParams = {}): Promise<number> {
     const parameters = prepareSearchParameters({
       ...params,
-      exclude_tags: [
-        ...new Set([...(params.exclude_tags || []), taggingUtils.generateAppDataFlagTag()]),
-      ],
+      exclude_flags: [taggingUtils.generateAppDataFlagTag()],
     });
     return recordService.searchRecords(ownerId, parameters, true).then(result => result.totalCount);
   },
@@ -627,9 +632,7 @@ const fhirService = {
   fetchResources(ownerId: string, params: IParams = {}): Promise<IFetchResponse> {
     const parameters = prepareSearchParameters({
       ...params,
-      exclude_tags: [
-        ...new Set([...(params.exclude_tags || []), taggingUtils.generateAppDataFlagTag()]),
-      ],
+      exclude_flags: [taggingUtils.generateAppDataFlagTag()],
     });
     return recordService.searchRecords(ownerId, parameters).then(result => ({
       records: result.records.map(convertToExposedRecord),

--- a/src/services/fhirService.ts
+++ b/src/services/fhirService.ts
@@ -381,6 +381,11 @@ export const prepareSearchParameters = (params: IParams) => {
     delete parameters.annotations;
   }
 
+  if (params.exclude_tags) {
+    const excludeTags = taggingUtils.generateCustomTags(params.exclude_tags)
+    parameters.exclude_tags = excludeTags
+  }
+
   return parameters;
 };
 

--- a/src/services/recordService.ts
+++ b/src/services/recordService.ts
@@ -46,6 +46,7 @@ export interface QueryParams {
   start_date?: string;
   end_date?: string;
   tags?: string[];
+  exclude_tags?: string[];
 }
 
 const recordService = {
@@ -205,16 +206,19 @@ const recordService = {
         // @ts-ignore
         .then(userObject => {
           user = userObject;
-
-          if (params?.tags?.length) {
-            return Promise.all(params.tags.map(tag => symEncryptString(user.tek, tag))).then(
-              tags => ({
-                ...params,
-                tags,
-              })
-            );
-          }
-          return params;
+          const encryptedTagsPromise = params?.tags?.length
+            ? Promise.all(params.tags.map(tag => symEncryptString(user.tek, tag)))
+            : Promise.resolve([]);
+          const encryptedExceptTagsPromise = params?.exclude_tags?.length
+            ? Promise.all(params.exclude_tags.map(tag => symEncryptString(user.tek, tag)))
+            : Promise.resolve([]);
+          return Promise.all([encryptedTagsPromise, encryptedExceptTagsPromise]).then(
+            ([tags, exclude_tags]) => ({
+              ...params,
+              tags,
+              exclude_tags,
+            })
+          );
         })
         .then(queryParams =>
           countOnly

--- a/src/services/recordService.ts
+++ b/src/services/recordService.ts
@@ -209,14 +209,14 @@ const recordService = {
           const encryptedTagsPromise = params?.tags?.length
             ? Promise.all(params.tags.map(tag => symEncryptString(user.tek, tag)))
             : Promise.resolve([]);
-          const encryptedExceptTagsPromise = params?.exclude_tags?.length
+          const excludeTagsPromise = params?.exclude_tags?.length
             ? Promise.all(params.exclude_tags.map(tag => symEncryptString(user.tek, tag)))
             : Promise.resolve([]);
-          return Promise.all([encryptedTagsPromise, encryptedExceptTagsPromise]).then(
-            ([tags, exclude_tags]) => ({
+          return Promise.all([encryptedTagsPromise, excludeTagsPromise]).then(
+            ([tags, excludeTags]) => ({
               ...params,
               tags,
-              exclude_tags,
+              exclude_tags: excludeTags,
             })
           );
         })

--- a/test/services/appDataServiceTest.js
+++ b/test/services/appDataServiceTest.js
@@ -91,7 +91,7 @@ describe('appDataService', () => {
         .then(res => {
           expect(uploadRecordStub).to.be.calledWith(userId);
           const { args: uploadRecordArgs } = uploadRecordStub.getCall(0);
-          expect(JSON.stringify(uploadRecordArgs)).to.contain('flag=appdata');
+          expect(JSON.stringify(uploadRecordArgs)).to.contain(testVariables.appDataFlag);
           expect(uploadRecordStub).to.be.calledOnce;
           expect(res).to.deep.equal(appData);
           done();
@@ -111,7 +111,7 @@ describe('appDataService', () => {
           expect(updateRecordStub).to.be.calledWith(userId, {
             id: 'id',
             data: appDataEntity,
-            tags: ['flag=appdata'],
+            tags: [testVariables.appDataFlag],
             customCreationDate,
           });
           expect(res).to.deep.equal(appData);
@@ -141,7 +141,7 @@ describe('appDataService', () => {
         .fetchAllAppData(userId)
         .then(() => {
           expect(searchRecordsStub).to.be.calledWith(testVariables.userId, {
-            tags: ['flag=appdata'],
+            tags: [testVariables.appDataFlag],
           });
           done();
         })

--- a/test/services/fhirServiceTest.js
+++ b/test/services/fhirServiceTest.js
@@ -79,6 +79,40 @@ describe('prepareSearchParameters', () => {
     });
   });
 
+  it('correctly prepares parameters with exclude_tags', () => {
+    const preparedParams = prepareSearchParameters({
+      tags: ['superhero-origin-story'],
+      exclude_tags: ['superman'],
+    });
+    expect(preparedParams).to.deep.equal({
+      tags: ['superhero-origin-story'],
+      exclude_tags: ['custom=superman'],
+    });
+  });
+
+  it('correctly prepares parameters with exclude_flags', () => {
+    const preparedParams = prepareSearchParameters({
+      tags: ['superhero-origin-story'],
+      exclude_flags: [testVariables.appDataFlag],
+    });
+    expect(preparedParams).to.deep.equal({
+      tags: ['superhero-origin-story'],
+      exclude_tags: [testVariables.appDataFlag],
+    });
+  });
+
+  it('correctly prepares parameters with exclude_tags and exclude_flags', () => {
+    const preparedParams = prepareSearchParameters({
+      tags: ['superhero-origin-story'],
+      exclude_tags: ['superman'],
+      exclude_flags: [testVariables.appDataFlag],
+    });
+    expect(preparedParams).to.deep.equal({
+      tags: ['superhero-origin-story'],
+      exclude_tags: ['custom=superman', testVariables.appDataFlag],
+    });
+  });
+
   it('throws when an unsupported parameter is passed', () => {
     expect(() => prepareSearchParameters({ illegalTag: 'suchIllegalMuchEvil' })).to.throw();
   });

--- a/test/services/fhirServiceTest.js
+++ b/test/services/fhirServiceTest.js
@@ -745,7 +745,7 @@ describe('fhirService', () => {
         .fetchResources(testVariables.userId, {})
         .then(() => {
           expect(searchRecordsStub).to.be.calledWith(testVariables.userId, {
-            exclude_tags: ['flag=appdata'],
+            exclude_tags: [testVariables.customAppDataFlag],
             tags: [],
           });
           done();
@@ -760,7 +760,7 @@ describe('fhirService', () => {
         .then(() => {
           expect(searchRecordsStub).to.be.calledWith(testVariables.userId, {
             tags: ['resourcetype=documentreference'],
-            exclude_tags: ['flag=appdata'],
+            exclude_tags: [testVariables.customAppDataFlag],
           });
           done();
         })
@@ -774,7 +774,7 @@ describe('fhirService', () => {
         .then(() => {
           expect(searchRecordsStub).to.be.calledWith(testVariables.userId, {
             tags: ['partner=glumpany'],
-            exclude_tags: ['flag=appdata'],
+            exclude_tags: [testVariables.customAppDataFlag],
           });
           expect(parameters.partner).to.equal('glumpany');
           done();
@@ -802,7 +802,10 @@ describe('fhirService', () => {
         .then(() => {
           expect(searchRecordsStub).to.be.calledWith(
             testVariables.userId,
-            { tags: ['resourcetype=documentreference'], exclude_tags: ['flag=appdata'] },
+            {
+              tags: ['resourcetype=documentreference'],
+              exclude_tags: [testVariables.customAppDataFlag],
+            },
             true
           );
           done();
@@ -817,7 +820,7 @@ describe('fhirService', () => {
         .then(() => {
           expect(searchRecordsStub).to.be.calledWith(
             testVariables.userId,
-            { tags: ['partner=glumpany'], exclude_tags: ['flag=appdata'] },
+            { tags: ['partner=glumpany'], exclude_tags: [testVariables.customAppDataFlag] },
             true
           );
           expect(parameters.partner).to.equal('glumpany');

--- a/test/services/fhirServiceTest.js
+++ b/test/services/fhirServiceTest.js
@@ -745,7 +745,7 @@ describe('fhirService', () => {
         .fetchResources(testVariables.userId, {})
         .then(() => {
           expect(searchRecordsStub).to.be.calledWith(testVariables.userId, {
-            exclude_tags: [testVariables.customAppDataFlag],
+            exclude_tags: [testVariables.appDataFlag],
             tags: [],
           });
           done();
@@ -760,7 +760,7 @@ describe('fhirService', () => {
         .then(() => {
           expect(searchRecordsStub).to.be.calledWith(testVariables.userId, {
             tags: ['resourcetype=documentreference'],
-            exclude_tags: [testVariables.customAppDataFlag],
+            exclude_tags: [testVariables.appDataFlag],
           });
           done();
         })
@@ -774,7 +774,7 @@ describe('fhirService', () => {
         .then(() => {
           expect(searchRecordsStub).to.be.calledWith(testVariables.userId, {
             tags: ['partner=glumpany'],
-            exclude_tags: [testVariables.customAppDataFlag],
+            exclude_tags: [testVariables.appDataFlag],
           });
           expect(parameters.partner).to.equal('glumpany');
           done();
@@ -804,7 +804,7 @@ describe('fhirService', () => {
             testVariables.userId,
             {
               tags: ['resourcetype=documentreference'],
-              exclude_tags: [testVariables.customAppDataFlag],
+              exclude_tags: [testVariables.appDataFlag],
             },
             true
           );
@@ -820,7 +820,7 @@ describe('fhirService', () => {
         .then(() => {
           expect(searchRecordsStub).to.be.calledWith(
             testVariables.userId,
-            { tags: ['partner=glumpany'], exclude_tags: [testVariables.customAppDataFlag] },
+            { tags: ['partner=glumpany'], exclude_tags: [testVariables.appDataFlag] },
             true
           );
           expect(parameters.partner).to.equal('glumpany');

--- a/test/services/recordServiceTest.js
+++ b/test/services/recordServiceTest.js
@@ -324,6 +324,7 @@ describe('services/recordService', () => {
         offset: 20,
         start_date: '2017-06-06',
         end_date: '2017-08-08',
+        exclude_tags: [testVariables.customAppDataFlag],
         tags: [testVariables.tag, testVariables.secondTag],
       };
 
@@ -332,6 +333,7 @@ describe('services/recordService', () => {
         offset: 20,
         start_date: '2017-06-06',
         end_date: '2017-08-08',
+        exclude_tags: [encryptionResources.encryptedString],
         tags: [encryptionResources.encryptedString, encryptionResources.encryptedString],
       };
 
@@ -370,6 +372,7 @@ describe('services/recordService', () => {
       };
 
       const expectedParamsForRoute = {
+        exclude_tags: [],
         tags: [encryptionResources.encryptedString],
       };
 

--- a/test/testUtils/testVariables.js
+++ b/test/testUtils/testVariables.js
@@ -23,7 +23,7 @@ const testVariables = {
   updatedByPartnerTag: 'updatedbypartner=2',
   encodedTag: 'client=ann%5Fotation',
   customTag: 'custom=annotation',
-  customAppDataFlag: 'custom=flag%3Dappdata',
+  appDataFlag: 'flag=appdata',
   encryptedTag: 'encrypted_tag',
   tek: 'tag_encryption_key',
   encryptedTek: 'encrypted_tag_encryption_key',

--- a/test/testUtils/testVariables.js
+++ b/test/testUtils/testVariables.js
@@ -23,6 +23,7 @@ const testVariables = {
   updatedByPartnerTag: 'updatedbypartner=2',
   encodedTag: 'client=ann%5Fotation',
   customTag: 'custom=annotation',
+  customAppDataFlag: 'custom=flag%3Dappdata',
   encryptedTag: 'encrypted_tag',
   tek: 'tag_encryption_key',
   encryptedTek: 'encrypted_tag_encryption_key',


### PR DESCRIPTION
### Summary of the issue
- as discussed in slack: `exclude_tags` need to be encrypted
- I also opened a PR in phdp-records to make the tags be combined with `or` (merged now)

### How to reproduce your bugfix or feature
Describe how to inspect and verify your changes.

### Due diligence checklist
- [x] Updated version in package.json if applicable.
- [x] Added/updated tests.
- [ ] Add documentation
- [ ] If this change affects SDK consumers: communicate changes.


### TODOs
- [ ] Mention any outstanding issues or tasks you need to perform after the merge.
