### PR TITLE
✅ 🎨📝 ⬆️ R4 clarifications, improved validation

### DIFF
--- a/docs/sdk.md
+++ b/docs/sdk.md
@@ -652,7 +652,9 @@ D4L.SDK.countResources('1cf5ee52-88dc-406a-bf7b-bc5e26a17b47', {
 
 ### Models
 
-The Data4Life platform supports multiple resource types. The resource types are reflected in the models.
+The Data4Life platform supports multiple resource types. It is up to integrators to build and supply these, the SDK merely validates supported resources.
+
+Exception: Within an STU3 context, the SDK provides the models below.
 
 #### DocumentReference
 To describe a document that's made available to a healthcare system, use the `DocumentReference` resource.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@d4l/js-sdk",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@d4l/js-sdk",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "D4L": {
     "data_model_version": 1
   },

--- a/src/lib/fhirValidator.ts
+++ b/src/lib/fhirValidator.ts
@@ -213,7 +213,24 @@ const fhirValidator = {
     const validationResult = validator(resourceToValidate);
 
     if (!validationResult) {
-      throw new ValidationError(`Validating "${resourceType}" failed.`);
+      let errorMessage = `Validating "${resourceType}" failed. `;
+      if (validator.errors?.length) {
+        errorMessage += `The following error(s) were encountered: `;
+        errorMessage += validator.errors
+          .map(errorObject => {
+            let messageBlock = `For ${errorObject.keyword}: ${errorObject.message}. There might be additional information below. \n`;
+            if (errorObject.dataPath?.length) {
+              messageBlock += `dataPath: ${errorObject.dataPath} `;
+            }
+            if (errorObject.schemaPath?.length) {
+              messageBlock += `schemaPath: ${errorObject.schemaPath}`;
+            }
+
+            return messageBlock;
+          })
+          .join(`\n`);
+      }
+      throw new ValidationError(errorMessage);
     }
 
     return true;

--- a/src/services/fhirService.ts
+++ b/src/services/fhirService.ts
@@ -427,9 +427,7 @@ const fhirService = {
     try {
       validationResult = await fhirValidator.validate(cleanResource(cloneDeep(fhirResource)));
     } catch (e) {
-      return Promise.reject(
-        new ValidationError(e)
-      );
+      return Promise.reject(new ValidationError(e));
     }
 
     if (validationResult === false) {

--- a/src/services/fhirService.ts
+++ b/src/services/fhirService.ts
@@ -425,10 +425,10 @@ const fhirService = {
   ): Promise<IRecord> {
     let validationResult;
     try {
-      validationResult = await fhirValidator.validate(fhirResource);
+      validationResult = await fhirValidator.validate(cleanResource(cloneDeep(fhirResource)));
     } catch (e) {
       return Promise.reject(
-        new ValidationError('Called createResource with an invalid fhirResource parameter.')
+        new ValidationError(e)
       );
     }
 

--- a/test/lib/fhirValidatorTest.ts
+++ b/test/lib/fhirValidatorTest.ts
@@ -848,11 +848,6 @@ describe('fhir validator', () => {
     for (const [exampleDomainName, resourceExamples] of Object.entries(exampleR4Collection)) {
       describe(exampleDomainName, () => {
         resourceExamples.forEach(resourceExample => {
-          if (exampleDomainName === 'DocumentReference') {
-            console.log(resourceExample);
-            // @ts-ignore
-            console.log(Object.values(resourceExample)[0].resourceType);
-          }
           it(`validates the sample ${Object.keys(resourceExample)[0]}`, done => {
             fhirValidator
               .validate(Object.values(resourceExample)[0])

--- a/test/lib/fhirValidatorTest.ts
+++ b/test/lib/fhirValidatorTest.ts
@@ -297,8 +297,8 @@ import ResearchSubjectExampleR4 from './resources/r4/researchsubject-example.jso
 import fhirService from '../../src/services/fhirService';
 import { FHIR_VERSION_STU3, FHIR_VERSION_R4 } from '../../src/lib/models/fhir/helper';
 import sinon from 'sinon';
-
-// @ts-ignore-disable
+import stu3FhirResources from '../testUtils/stu3FhirResources';
+import r4FhirResources from '../testUtils/r4FhirResources';
 
 chai.use(sinonChai);
 
@@ -483,7 +483,13 @@ describe('fhir validator', () => {
         { diagnosticReportExampleSTU3PGX },
         { diagnosticReportExampleSTU3UltraSound },
       ],
-      DocumentReference: [{ documentReferenceExample: documentReferenceExampleSTU3 }],
+      DocumentReference: [
+        { documentReferenceExampleSTU3 },
+        {
+          // @ts-ignore
+          generatedReference: stu3FhirResources.documentReference,
+        },
+      ],
       Organization: [
         { organizationExampleSTU31 },
         { organizationExampleSTU3BurgersUniversity },
@@ -694,6 +700,8 @@ describe('fhir validator', () => {
         { documentReferenceExampleS4HTreatmentSeries },
         { documentReferenceExampleS4HAttachment },
         { documentReferenceExampleS4HTreatmentSeriesPreSession },
+        { generatedDocumentReference: r4FhirResources.documentReference },
+        { generatedDocumentReference2: r4FhirResources.documentReference2 },
       ],
       Encounter: [
         { encounterExampleR4 },
@@ -836,12 +844,15 @@ describe('fhir validator', () => {
       ResearchSubject: [{ ResearchSubjectExampleR4 }],
     };
 
-    // todo: refactor to share
-
     // eslint-disable-next-line no-restricted-syntax
     for (const [exampleDomainName, resourceExamples] of Object.entries(exampleR4Collection)) {
       describe(exampleDomainName, () => {
         resourceExamples.forEach(resourceExample => {
+          if (exampleDomainName === 'DocumentReference') {
+            console.log(resourceExample);
+            // @ts-ignore
+            console.log(Object.values(resourceExample)[0].resourceType);
+          }
           it(`validates the sample ${Object.keys(resourceExample)[0]}`, done => {
             fhirValidator
               .validate(Object.values(resourceExample)[0])

--- a/test/lib/models/fhir/documentReferenceTest.ts
+++ b/test/lib/models/fhir/documentReferenceTest.ts
@@ -118,7 +118,9 @@ describe('models/FHIR', () => {
     });
 
     it('should return valid Document instance with fromFHIRObject', () => {
-      const documentReference = DocumentReference.fromFHIRObject(stu3FhirResources.documentReference);
+      const documentReference = DocumentReference.fromFHIRObject(
+        stu3FhirResources.documentReference
+      );
       expect(documentReference.getType().text).to.equal('Document');
     });
     it('should throw error when fromFHIRObject is called with no arguments', done => {

--- a/test/lib/models/fhir/documentReferenceTest.ts
+++ b/test/lib/models/fhir/documentReferenceTest.ts
@@ -8,7 +8,7 @@ import DocumentReference from '../../../../src/lib/models/fhir/DocumentReference
 import Attachment from '../../../../src/lib/models/fhir/Attachment';
 import Practitioner from '../../../../src/lib/models/fhir/Practitioner';
 import { createCodeableConcept } from '../../../../src/lib/models/fhir/helper';
-import fhirResources from '../../../testUtils/fhirResources';
+import stu3FhirResources from '../../../testUtils/stu3FhirResources';
 
 chai.use(sinonChai);
 
@@ -118,7 +118,7 @@ describe('models/FHIR', () => {
     });
 
     it('should return valid Document instance with fromFHIRObject', () => {
-      const documentReference = DocumentReference.fromFHIRObject(fhirResources.documentReference);
+      const documentReference = DocumentReference.fromFHIRObject(stu3FhirResources.documentReference);
       expect(documentReference.getType().text).to.equal('Document');
     });
     it('should throw error when fromFHIRObject is called with no arguments', done => {

--- a/test/services/fhirServiceTest.ts
+++ b/test/services/fhirServiceTest.ts
@@ -13,7 +13,7 @@ import fhirService, {
 } from '../../src/services/fhirService';
 import testVariables from '../testUtils/testVariables';
 import fhirValidator from '../../src/lib/fhirValidator';
-import fhirResources from '../testUtils/fhirResources';
+import stu3FhirResources from '../testUtils/stu3FhirResources';
 import recordService from '../../src/services/recordService';
 import { D4LSDK } from '../../src/d4l';
 import documentRoutes from '../../src/routes/documentRoutes';
@@ -384,7 +384,7 @@ describe('attachBlobs', () => {
           // @ts-ignore
           newAttachments: [newAttachment],
           // @ts-ignore
-          resource: new D4LSDK.models.DocumentReference(fhirResources.documentReference),
+          resource: new D4LSDK.models.DocumentReference(stu3FhirResources.documentReference),
         });
       })
       .then(([resource, returnResource]) => {
@@ -422,7 +422,7 @@ describe('attachBlobs', () => {
           oldAttachments: [],
           newAttachments: [newAttachment],
           // @ts-ignore
-          resource: new D4LSDK.models.DocumentReference(fhirResources.documentReference),
+          resource: new D4LSDK.models.DocumentReference(stu3FhirResources.documentReference),
         });
       })
       .then(([resource, returnResource]) => {
@@ -462,7 +462,7 @@ describe('attachBlobs', () => {
           oldAttachments: [],
           newAttachments: [attachment],
           // @ts-ignore
-          resource: new D4LSDK.models.DocumentReference(fhirResources.documentReference),
+          resource: new D4LSDK.models.DocumentReference(stu3FhirResources.documentReference),
         });
       })
       .then(([resource, returnResource]) => {
@@ -501,7 +501,7 @@ describe('attachBlobs', () => {
           oldAttachments: [],
           newAttachments: [attachment],
           // @ts-ignore
-          resource: new D4LSDK.models.DocumentReference(fhirResources.documentReference),
+          resource: new D4LSDK.models.DocumentReference(stu3FhirResources.documentReference),
         });
       })
       .then(([resource, returnResource]) => {
@@ -537,7 +537,7 @@ describe('attachBlobs', () => {
         // technically not encrypted at this point
         const encryptedFiles = [mockPdfBlob];
         // @ts-ignore
-        const resource = new D4LSDK.models.DocumentReference(fhirResources.documentReference);
+        const resource = new D4LSDK.models.DocumentReference(stu3FhirResources.documentReference);
         resource.setAttachments([oldAttachment]);
 
         return attachBlobs({
@@ -592,7 +592,7 @@ describe('attachBlobs', () => {
         // technically not encrypted at this point
         const encryptedFiles = [mockPngBlob, mockPngBlob, mockPngBlob, mockPdfBlob];
         // @ts-ignore
-        const resource = new D4LSDK.models.DocumentReference(fhirResources.documentReference);
+        const resource = new D4LSDK.models.DocumentReference(stu3FhirResources.documentReference);
         resource.setAttachments([oldAttachment]);
 
         return attachBlobs({
@@ -640,7 +640,7 @@ describe('fhirService', () => {
     id: recordId,
     customCreationDate: new Date('2017-09-19'),
     user_id: userId,
-    fhirResource: fhirResources.carePlan,
+    fhirResource: stu3FhirResources.carePlan,
     tags: ['tag1', 'tag2', testVariables.secondTag],
     version: 1,
     status: 'Active',
@@ -650,7 +650,7 @@ describe('fhirService', () => {
   const record = {
     id: recordId,
     customCreationDate: new Date('2017-09-19'),
-    fhirResource: fhirResources.carePlan,
+    fhirResource: stu3FhirResources.carePlan,
     updatedDate: new Date('2017-09-19T09:29:48.278'),
     annotations: [],
     partner: '1',
@@ -768,7 +768,7 @@ describe('fhirService', () => {
         {
           id: testVariables.recordId,
         },
-        fhirResources.carePlan
+        stu3FhirResources.carePlan
       );
       const customCreationDate = new Date();
       fhirService
@@ -789,7 +789,7 @@ describe('fhirService', () => {
     });
 
     it('should reject a resource without an id', done => {
-      const d4lResource = Object.assign({}, fhirResources.carePlan);
+      const d4lResource = Object.assign({}, stu3FhirResources.carePlan);
       // @ts-ignore
       delete d4lResource.id;
       fhirService

--- a/test/services/recordServiceTest.ts
+++ b/test/services/recordServiceTest.ts
@@ -19,7 +19,7 @@ import * as createCryptoService from '../../src/services/createCryptoService';
 import testVariables from '../testUtils/testVariables';
 import documentResources from '../testUtils/documentResources';
 import userResources from '../testUtils/userResources';
-import fhirResources from '../testUtils/fhirResources';
+import stu3FhirResources from '../testUtils/stu3FhirResources';
 import recordResources from '../testUtils/recordResources';
 import encryptionResources from '../testUtils/encryptionResources';
 import recordService from '../../src/services/recordService';
@@ -84,7 +84,7 @@ describe('services/recordService', () => {
     // CREATECRYPTOSERVICE
     decryptDataStub = sinon
       .stub()
-      .returns(Promise.resolve(convertObjectToArrayBufferView(fhirResources.documentReference)));
+      .returns(Promise.resolve(convertObjectToArrayBufferView(stu3FhirResources.documentReference)));
     encryptObjectStub = sinon.stub().returns(
       Promise.resolve([
         encryptionResources.encryptedObject,
@@ -138,12 +138,12 @@ describe('services/recordService', () => {
     it('should resolve when called with userId and correct fhirResource', done => {
       const tags = [
         taggingUtils.generateCreationTag(),
-        ...taggingUtils.generateTagsFromFhir(fhirResources.documentReference),
+        ...taggingUtils.generateTagsFromFhir(stu3FhirResources.documentReference),
       ];
 
       recordService
         .createRecord(testVariables.userId, {
-          fhirResource: fhirResources.documentReference,
+          fhirResource: stu3FhirResources.documentReference,
         })
         .then(() => {
           expect(createRecordStub).to.be.calledOnce;
@@ -152,11 +152,11 @@ describe('services/recordService', () => {
           );
           expect(createRecordStub).to.be.calledWith(testVariables.userId);
           expect(validateStub).to.be.calledOnce;
-          expect(validateStub).to.be.calledWith(fhirResources.documentReference);
+          expect(validateStub).to.be.calledWith(stu3FhirResources.documentReference);
           expect(getUserStub).to.be.calledOnce;
           expect(getUserStub).to.be.calledWith(testVariables.userId);
           expect(recordServiceUploadRecordSpy).to.be.calledWith(testVariables.userId, {
-            fhirResource: fhirResources.documentReference,
+            fhirResource: stu3FhirResources.documentReference,
             tags,
           });
           done();
@@ -170,7 +170,7 @@ describe('services/recordService', () => {
       recordService
         // @ts-ignore
         .uploadFhirRecord(testVariables.userId, {
-          fhirResource: fhirResources.documentReference,
+          fhirResource: stu3FhirResources.documentReference,
         })
         .then(() => done(Error("fhirValidation didn't fail as expected")))
         .catch(() => {
@@ -187,7 +187,7 @@ describe('services/recordService', () => {
       recordService
         .updateRecord(testVariables.userId, {
           id: testVariables.recordId,
-          fhirResource: fhirResources.documentReference,
+          fhirResource: stu3FhirResources.documentReference,
         })
         .then(res => {
           expect(res.id).to.deep.equal(testVariables.recordId);
@@ -215,7 +215,7 @@ describe('services/recordService', () => {
       recordService
         .updateRecord(testVariables.userId, {
           id: testVariables.recordId,
-          fhirResource: fhirResources.documentReference,
+          fhirResource: stu3FhirResources.documentReference,
           attachmentKey: {
             commonKeyId: customCkId,
             encryptedKey: encryptionResources.encryptedAttachmentKey,
@@ -247,13 +247,13 @@ describe('services/recordService', () => {
       const tags = [
         ...taggingUtils.generateCustomTags(documentResources.annotations),
         taggingUtils.generateUpdateTag(),
-        ...taggingUtils.generateTagsFromFhir(fhirResources.documentReference),
+        ...taggingUtils.generateTagsFromFhir(stu3FhirResources.documentReference),
       ];
 
       recordService
         .updateRecord(testVariables.userId, {
           id: testVariables.recordId,
-          fhirResource: fhirResources.documentReference,
+          fhirResource: stu3FhirResources.documentReference,
           tags: taggingUtils.generateCustomTags(documentResources.annotations),
         })
         .then(res => {
@@ -267,7 +267,7 @@ describe('services/recordService', () => {
           ]);
           expect(recordServiceUploadRecordSpy).to.be.calledWith(testVariables.userId, {
             id: testVariables.recordId,
-            fhirResource: fhirResources.documentReference,
+            fhirResource: stu3FhirResources.documentReference,
             tags,
           });
           done();
@@ -281,7 +281,7 @@ describe('services/recordService', () => {
       recordService
         .downloadRecord(testVariables.userId, testVariables.recordId)
         .then(res => {
-          expect(res.fhirResource).to.deep.equal(fhirResources.documentReference);
+          expect(res.fhirResource).to.deep.equal(stu3FhirResources.documentReference);
           expect(downloadRecordStub).to.be.calledOnce;
           expect(downloadRecordStub).to.be.calledWith(testVariables.userId);
           expect(getUserStub).to.be.calledOnce;

--- a/test/services/recordServiceTest.ts
+++ b/test/services/recordServiceTest.ts
@@ -84,7 +84,9 @@ describe('services/recordService', () => {
     // CREATECRYPTOSERVICE
     decryptDataStub = sinon
       .stub()
-      .returns(Promise.resolve(convertObjectToArrayBufferView(stu3FhirResources.documentReference)));
+      .returns(
+        Promise.resolve(convertObjectToArrayBufferView(stu3FhirResources.documentReference))
+      );
     encryptObjectStub = sinon.stub().returns(
       Promise.resolve([
         encryptionResources.encryptedObject,

--- a/test/testUtils/r4FhirResources.ts
+++ b/test/testUtils/r4FhirResources.ts
@@ -23,35 +23,35 @@ const r4FhirResources = {
     ],
   },
   documentReference2: {
-    "resourceType": "DocumentReference",
-    "status": "current",
-    "type": {
-      "coding": [
+    resourceType: 'DocumentReference',
+    status: 'current',
+    type: {
+      coding: [
         {
-          "display": "LabBefund"
-        }
-      ]
+          display: 'LabBefund',
+        },
+      ],
     },
-    "author": [
+    author: [
       {
-        "reference": "#contained-author-id"
-      }
+        reference: '#contained-author-id',
+      },
     ],
-    "description": "sefsf",
-    "subject": {
-      "reference": "sefsf"
+    description: 'sefsf',
+    subject: {
+      reference: 'sefsf',
     },
-    "contained": [],
-    "content": [
+    contained: [],
+    content: [
       {
-        "attachment": {
-          "contentType": "image/png",
-          "creation": "2020-10-08T10:00:00.000Z",
-          "title": "Bildschirmfoto 2020-10-13 um 17.18.54.png"
-        }
-      }
+        attachment: {
+          contentType: 'image/png',
+          creation: '2020-10-08T10:00:00.000Z',
+          title: 'Bildschirmfoto 2020-10-13 um 17.18.54.png',
+        },
+      },
     ],
-    "date": "2020-10-08T10:00:00.000Z"
+    date: '2020-10-08T10:00:00.000Z',
   },
 };
 

--- a/test/testUtils/r4FhirResources.ts
+++ b/test/testUtils/r4FhirResources.ts
@@ -1,0 +1,58 @@
+import testVariables from './testVariables';
+
+const r4FhirResources = {
+  documentReference: {
+    id: 'recordid',
+    resourceType: 'DocumentReference',
+    status: 'current',
+    date: testVariables.dateTimeString,
+    type: {
+      text: 'Document',
+    },
+    author: [{ display: 'Julius' }],
+    subject: { reference: 'CT' },
+    content: [
+      {
+        attachment: {
+          id: testVariables.fileId,
+          title: '20171214_131101.jpg',
+          contentType: 'image/jpeg',
+          creation: testVariables.dateString,
+        },
+      },
+    ],
+  },
+  documentReference2: {
+    "resourceType": "DocumentReference",
+    "status": "current",
+    "type": {
+      "coding": [
+        {
+          "display": "LabBefund"
+        }
+      ]
+    },
+    "author": [
+      {
+        "reference": "#contained-author-id"
+      }
+    ],
+    "description": "sefsf",
+    "subject": {
+      "reference": "sefsf"
+    },
+    "contained": [],
+    "content": [
+      {
+        "attachment": {
+          "contentType": "image/png",
+          "creation": "2020-10-08T10:00:00.000Z",
+          "title": "Bildschirmfoto 2020-10-13 um 17.18.54.png"
+        }
+      }
+    ],
+    "date": "2020-10-08T10:00:00.000Z"
+  },
+};
+
+export default r4FhirResources;

--- a/test/testUtils/recordResources.ts
+++ b/test/testUtils/recordResources.ts
@@ -1,5 +1,5 @@
 import testVariables from './testVariables';
-import fhirResources from './fhirResources';
+import stu3FhirResources from './stu3FhirResources';
 import encryptionResources from './encryptionResources';
 
 const recordResources = {
@@ -11,7 +11,7 @@ const recordResources = {
     version: 2,
     status: 'Active',
     createdAt: testVariables.dateTimeString,
-    body: fhirResources.documentReference,
+    body: stu3FhirResources.documentReference,
     tags: [testVariables.tag, testVariables.secondTag, testVariables.customTag],
   },
   documentReferenceEncrypted: {
@@ -22,7 +22,7 @@ const recordResources = {
     version: 2,
     status: 'Active',
     createdAt: testVariables.dateTimeString,
-    encrypted_body: fhirResources.encryptedFhir,
+    encrypted_body: stu3FhirResources.encryptedFhir,
     encrypted_tags: [testVariables.encryptedTag],
     encrypted_key: encryptionResources.encryptedDataKey,
   },

--- a/test/testUtils/stu3FhirResources.ts
+++ b/test/testUtils/stu3FhirResources.ts
@@ -1,6 +1,6 @@
 import testVariables from './testVariables';
 
-const fhirResources = {
+const stu3FhirResources = {
   documentReference: {
     id: 'record_id',
     resourceType: 'DocumentReference',
@@ -216,4 +216,4 @@ const fhirResources = {
     '8h1d2xeor7VkgG0W7cCLsRzXMMaiSafCA8WjS0DW9x3Xw11+ffZoUKQBq01tImdokPGoGmxiagtxYcOG3ugcBpN8gK3dkOr3ho8G2ToIeu+mzCgSA5UwafSJriiQqwwfDFnUGYdvP3ldNJXC4r9qrMMdbhYIsgUjPX5X/YbXso9EhRqmjtW3J46bGNrCoef3Y+j9mu+3oyx6LBukddH+TUFeFzPWxuCATAeVCIRlwnyc+eAbv+FECjPgjQyjrvwHPuUA9/mpWPg/TIaJ0VIzalLwpeLtyre1USRLEnYUzR4jAbQLV8v8jQg6YRVZuBgtEkD0Z/nyro8B1Plh4JWRza64gYYr4cUu/8gaw/pBOkaTnaZhUnV5O6j9awDFUSud+CJoysQsphNm840Cjztj9qZj2/gW1X2PWYAtjlC/1HiDGxs+N5omsxSzrSZnbaYghvhx9oXE9VIFNmlGarqQqw==',
 };
 
-export default fhirResources;
+export default stu3FhirResources;

--- a/test/testUtils/testVariables.ts
+++ b/test/testUtils/testVariables.ts
@@ -24,7 +24,7 @@ const testVariables = {
   password: 'password',
   wrongPassword: 'wrong_password',
   dateString: '2017-12-15',
-  dateTimeString: '2017-12-15T10:35:52.492',
+  dateTimeString: '2017-12-15T10:35:52Z',
   tag: 'resourcetype=documentreference',
   // encrypted with encryptionResources.tagEncryptionKey
   encryptedTag: 'oEYB2yHZ26/+mdqTDOIjQnwU7cl49Ldf3HjATcNofnk=',


### PR DESCRIPTION
### Summary of the issue
This cleans up a few issues that came up after the release of 3.0.0 (and before).

For once, while we have employed AJV for its validation for a while, getting the actual errors has always been difficult and required either custom local SDK builds or step-by-step debugging in the browser. No more! We now directly **pass through a well-formatted list of all the validation woes**.

Furthermore, in the past we sent the original resource that was sent to `createResource` to the validator and we were fairly lucky that didn't bite us. However, documentReferences in R4 for instance don't actually support any additional properties such as the file property that we strip off the resource later in the process, so the validation would fail. As a solution, we now preemptively **sent a cleaned version of the resource to the validator**.

Back in the olden days, a lot of the usage of the SDK was centered around instantiating the models we provided, but that has shifted a little bit - we no longer provide models for every new resourcetype we support, and indeed it's a bit misleading to have the STU3-based models in there. While we debate on the exact future pathway, the documentation for this section clarified our current stance a bit. And we should also signal which FHIR version all the examples we use actually adhere to, hence the corresponding resource files have been renamed.

### Due diligence checklist
- [x] Updated version in package.json if applicable.
- [x] Added/updated tests.
- [x] Add documentation
- [x] If this change affects SDK consumers: communicate changes.


### TODOs
- [ ] Mention any outstanding issues or tasks you need to perform after the merge.
