### PR TITLE
🐛 validate against cleaned resources for update calls as well

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@d4l/js-sdk",
-  "version": "4.0.0",
+  "version": "4.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@d4l/js-sdk",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "D4L": {
     "data_model_version": 1
   },

--- a/src/services/fhirService.ts
+++ b/src/services/fhirService.ts
@@ -506,11 +506,20 @@ const fhirService = {
     date,
     annotations?: string[]
   ): Promise<IRecord> {
-    if (!fhirValidator.validate(fhirResource)) {
+    let validationResult;
+    try {
+      validationResult = await fhirValidator.validate(cleanResource(cloneDeep(fhirResource)));
+    } catch (e) {
+      return Promise.reject(new ValidationError(e));
+    }
+
+    if (validationResult === false) {
+      // seems redundant, but eslint does not like return in finally
       return Promise.reject(
         new ValidationError('Called updateResource with an invalid fhirResource parameter.')
       );
     }
+
     if (!fhirResource.id) {
       return Promise.reject(new ValidationError('No parameter id found in resource to update'));
     }


### PR DESCRIPTION
### Summary of the issue
With #27, we adapted the validation in the `create` method to validate against a cleaned version without attachments that we handle later, but that would break validation. This PR does the same for the `update` call. 

### Due diligence checklist
- [x] Updated version in package.json if applicable.
- [ ] Added/updated tests.
- [ ] Add documentation
- [ ] If this change affects SDK consumers: communicate changes.

