### PR TITLE
✨🐛✅ delete existing tags/annotations when an update method supplies an empty array

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    env:
+      ACTIONS_ALLOW_UNSECURE_COMMANDS: true
     steps:
       - name: Add @d4l/js-crypto deploy key
         uses: webfactory/ssh-agent@v0.2.0

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,11 +8,9 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    env:
-      ACTIONS_ALLOW_UNSECURE_COMMANDS: true
     steps:
       - name: Add @d4l/js-crypto deploy key
-        uses: webfactory/ssh-agent@v0.2.0
+        uses: webfactory/ssh-agent@v0.4.1
         with:
           ssh-private-key: ${{ secrets.JS_CRYPTO_DEPLOY_KEY }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,12 +10,10 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    env:
-      ACTIONS_ALLOW_UNSECURE_COMMANDS: true
     steps:
       - uses: actions/checkout@master
       - name: Add js-crypto ssh key
-        uses: webfactory/ssh-agent@v0.2.0
+        uses: webfactory/ssh-agent@v0.4.1
         with:
           ssh-private-key: ${{ secrets.JS_CRYPTO_DEPLOY_KEY }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,8 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    env:
+      ACTIONS_ALLOW_UNSECURE_COMMANDS: true
     steps:
       - uses: actions/checkout@master
       - name: Add js-crypto ssh key

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@d4l/js-sdk",
-  "version": "5.0.0-alpha.1",
+  "version": "5.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@d4l/js-sdk",
-  "version": "5.0.0-alpha.1",
+  "version": "5.0.0",
   "D4L": {
     "data_model_version": 1
   },

--- a/src/services/appDataService.ts
+++ b/src/services/appDataService.ts
@@ -72,18 +72,26 @@ const appDataService = {
     data: any,
     id: string,
     date,
-    annotations: string[] = []
+    annotations?: string[]
   ): Promise<any> {
+    let tags;
+    /* eslint-disable indent */
+    if (annotations) {
+      tags = annotations.length
+        ? [
+            ...new Set([
+              ...taggingUtils.generateCustomTags(annotations),
+              taggingUtils.generateAppDataFlagTag(),
+            ]),
+          ]
+        : [];
+      /* eslint-enable indent */
+    }
     return recordService
       .updateRecord(ownerId, {
         data,
         id,
-        tags: [
-          ...new Set([
-            ...taggingUtils.generateCustomTags(annotations),
-            taggingUtils.generateAppDataFlagTag(),
-          ]),
-        ],
+        tags,
         customCreationDate: date,
       })
       .then(convertToExposedAppData);

--- a/src/services/fhirService.ts
+++ b/src/services/fhirService.ts
@@ -536,12 +536,17 @@ const fhirService = {
       );
     }
 
+    let tags;
+    if (annotations) {
+      tags = annotations.length ? taggingUtils.generateCustomTags(annotations) : [];
+    }
+
     return recordService
       .updateRecord(ownerId, {
         attachmentKey,
         fhirResource: cleanResource(resource || fhirResource),
         id: fhirResource.id,
-        tags: taggingUtils.generateCustomTags(annotations),
+        tags,
         customCreationDate: date,
       })
       .then(convertToExposedRecord)

--- a/src/services/recordService.ts
+++ b/src/services/recordService.ts
@@ -57,6 +57,15 @@ const recordService = {
       documentRoutes.updateRecord(userId, record.id, params);
 
     return this.downloadRecord(ownerId, record.id).then(downloadedRecord => {
+      let tags;
+      if (record.tags && !record.tags.length) {
+        tags = [taggingUtils.generateUpdateTag()];
+      } else {
+        tags = record.tags
+          ? [...new Set([...record.tags, taggingUtils.generateUpdateTag()])]
+          : [...new Set([...downloadedRecord.tags, taggingUtils.generateUpdateTag()])];
+      }
+
       /*
        * AppData case
        * */
@@ -65,13 +74,7 @@ const recordService = {
           ownerId,
           {
             ...record,
-            tags: [
-              ...new Set([
-                ...record.tags,
-                taggingUtils.generateUpdateTag(),
-                ...downloadedRecord.tags,
-              ]),
-            ],
+            tags,
           },
           updateRequest
         );
@@ -88,13 +91,7 @@ const recordService = {
             downloadedRecord.fhirResource,
             (record as DecryptedRecord).fhirResource
           ),
-          // include new tags passed in record,
-          // previous tags, and tags specific to update method
-          tags: [
-            ...(record.tags || []),
-            taggingUtils.generateUpdateTag(),
-            ...downloadedRecord.tags,
-          ],
+          tags,
         },
         updateRequest
       );

--- a/test/services/appDataServiceTest.ts
+++ b/test/services/appDataServiceTest.ts
@@ -101,7 +101,7 @@ describe('appDataService', () => {
   });
 
   describe('updateAppData', () => {
-    it('should update an AppData entity correctly', done => {
+    it('should update an AppData entity correctly when no annotations are submitted', done => {
       const appDataEntity = Object.assign({ sampleKey: 'SampleValue' });
       const customCreationDate = new Date();
       appDataService
@@ -111,7 +111,45 @@ describe('appDataService', () => {
           expect(updateRecordStub).to.be.calledWith(userId, {
             id: 'id',
             data: appDataEntity,
-            tags: [testVariables.appDataFlag],
+            tags: undefined,
+            customCreationDate,
+          });
+          expect(res).to.deep.equal(appData);
+          done();
+        })
+        .catch(done);
+    });
+
+    it('should update an AppData entity correctly when annotations are submitted', done => {
+      const appDataEntity = Object.assign({ sampleKey: 'SampleValue' });
+      const customCreationDate = new Date();
+      appDataService
+        .updateAppData(userId, appDataEntity, 'id', customCreationDate, ['addme'])
+        .then(res => {
+          expect(updateRecordStub).to.be.calledOnce;
+          expect(updateRecordStub).to.be.calledWith(userId, {
+            id: 'id',
+            data: appDataEntity,
+            tags: ['custom=addme', testVariables.appDataFlag],
+            customCreationDate,
+          });
+          expect(res).to.deep.equal(appData);
+          done();
+        })
+        .catch(done);
+    });
+
+    it('should update an AppData entity correctly when an empty annotations array is submitted', done => {
+      const appDataEntity = Object.assign({ sampleKey: 'SampleValue' });
+      const customCreationDate = new Date();
+      appDataService
+        .updateAppData(userId, appDataEntity, 'id', customCreationDate, [])
+        .then(res => {
+          expect(updateRecordStub).to.be.calledOnce;
+          expect(updateRecordStub).to.be.calledWith(userId, {
+            id: 'id',
+            data: appDataEntity,
+            tags: [],
             customCreationDate,
           });
           expect(res).to.deep.equal(appData);

--- a/test/services/fhirServiceTest.ts
+++ b/test/services/fhirServiceTest.ts
@@ -763,7 +763,7 @@ describe('fhirService', () => {
   });
 
   describe('updateResource', () => {
-    it('should update a resource correctly', done => {
+    it('should update a resource correctly when no annotations are added', done => {
       const d4lResource = Object.assign(
         {
           id: testVariables.recordId,
@@ -773,6 +773,56 @@ describe('fhirService', () => {
       const customCreationDate = new Date();
       fhirService
         .updateResource(userId, d4lResource, customCreationDate)
+        .then(res => {
+          expect(updateRecordStub).to.be.calledOnce;
+          expect(updateRecordStub).to.be.calledWith(userId, {
+            id: d4lResource.id,
+            fhirResource: d4lResource,
+            tags: undefined,
+            attachmentKey: undefined,
+            customCreationDate,
+          });
+          expect(res).to.deep.equal(record);
+          done();
+        })
+        .catch(done);
+    });
+
+    it('should update a resource correctly when annotations are added', done => {
+      const d4lResource = Object.assign(
+        {
+          id: testVariables.recordId,
+        },
+        stu3FhirResources.carePlan
+      );
+      const customCreationDate = new Date();
+      fhirService
+        .updateResource(userId, d4lResource, customCreationDate, ['addme'])
+        .then(res => {
+          expect(updateRecordStub).to.be.calledOnce;
+          expect(updateRecordStub).to.be.calledWith(userId, {
+            id: d4lResource.id,
+            fhirResource: d4lResource,
+            tags: ['custom=addme'],
+            attachmentKey: undefined,
+            customCreationDate,
+          });
+          expect(res).to.deep.equal(record);
+          done();
+        })
+        .catch(done);
+    });
+
+    it('should update a resource correctly when an empty annotations array is added', done => {
+      const d4lResource = Object.assign(
+        {
+          id: testVariables.recordId,
+        },
+        stu3FhirResources.carePlan
+      );
+      const customCreationDate = new Date();
+      fhirService
+        .updateResource(userId, d4lResource, customCreationDate, [])
         .then(res => {
           expect(updateRecordStub).to.be.calledOnce;
           expect(updateRecordStub).to.be.calledWith(userId, {

--- a/test/testUtils/recordResources.ts
+++ b/test/testUtils/recordResources.ts
@@ -26,6 +26,18 @@ const recordResources = {
     encrypted_tags: [testVariables.encryptedTag],
     encrypted_key: encryptionResources.encryptedDataKey,
   },
+  documentReferenceEncryptedTwoTags: {
+    record_id: testVariables.recordId,
+    date: testVariables.dateString,
+    user_id: testVariables.userId,
+    common_key_id: testVariables.commonKeyId,
+    version: 2,
+    status: 'Active',
+    createdAt: testVariables.dateTimeString,
+    encrypted_body: stu3FhirResources.encryptedFhir,
+    encrypted_tags: [testVariables.encryptedTag, testVariables.encryptedSecondTag],
+    encrypted_key: encryptionResources.encryptedDataKey,
+  },
 };
 
 export default recordResources;


### PR DESCRIPTION
### Summary of the issue
This aligns the behaviour of the JS SDK with the one for the other SDKs. When updating an entity (appData or fhirResource) that may contain tags, the following options are possible:
- do not supply tags: the original tags will be kept, plus any additions such an "updatedby" tag
- supply new tags: old tags will be removed and the new tags will be added, plus any additions such as an updatedby or resource tag
- supply an empty array as the tag parameter: old tags will be removed, no new tags will be added besides update/resource tags