### PR TITLE
🐛 fix bug where cleanResource would mutate an incoming resource

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@d4l/js-sdk",
-  "version": "5.3.0",
+  "version": "5.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@d4l/js-sdk",
-  "version": "5.3.0",
+  "version": "5.3.1",
   "D4L": {
     "data_model_version": 1
   },

--- a/src/services/fhirService.ts
+++ b/src/services/fhirService.ts
@@ -247,15 +247,14 @@ const addPreviewsToAttachments = async vanillaAttachments => {
 const uploadAttachments = (ownerId, encryptedFiles) =>
   Promise.all(encryptedFiles.map(file => documentRoutes.uploadDocument(ownerId, file)));
 
-const cleanResource = (fhirResource: fhir.DomainResource) => {
+export const cleanResource = (fhirResource: fhir.DomainResource) => {
   if (fhirResource.resourceType === DOCUMENT_REFERENCE) {
     // @ts-ignore
     if (fhirResource.content) {
+      const clonedResource = cloneDeep(fhirResource);
       // @ts-ignore
-      fhirResource.content = fhirResource.content.map(value => {
-        delete value.attachment.file;
-        return value;
-      });
+      clonedResource.content = fhirResource.content.map(value => omit(value, 'attachment.file'));
+      return clonedResource;
     }
   }
 
@@ -379,7 +378,7 @@ const fhirService = {
   ): Promise<Record> {
     let validationResult;
     try {
-      validationResult = await fhirValidator.validate(cleanResource(cloneDeep(fhirResource)));
+      validationResult = await fhirValidator.validate(cleanResource(fhirResource));
     } catch (e) {
       return Promise.reject(new ValidationError(e));
     }


### PR DESCRIPTION
### Summary of the issue
When we upload the a resource during its updating process, it is being cleaned of its actual attachment file contents as those do not go to the FHIRService, but are uploaded in the DocumentService. We also use a cleaned version for the validation, though that had been based on a deepCloned version of the resource already.

However, cleanResource _mutates_ its parameter resource when deleting attachments, which is not only kind-of-meh design-wise, but will also throw an error in case we are given immuable objects for this operation. In order to fix this, we know perform this on deepclone of the parameter. Added tests for both cases.


### How to reproduce your bugfix or feature
Describe how to inspect and verify your changes.

### Due diligence checklist
- [x] Updated version in package.json if applicable.
- [x] Added/updated tests.
- [ ] Add documentation
- [ ] If this change affects SDK consumers: communicate changes.


### TODOs
- [ ] Mention any outstanding issues or tasks you need to perform after the merge.
