### PR TITLE
🐛 fix a bug where an undefined author prop would crash

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@d4l/js-sdk",
-  "version": "5.3.1",
+  "version": "5.3.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@d4l/js-sdk",
-  "version": "5.3.1",
+  "version": "5.3.2",
   "D4L": {
     "data_model_version": 1
   },

--- a/src/lib/models/fhir/DocumentReference.ts
+++ b/src/lib/models/fhir/DocumentReference.ts
@@ -23,6 +23,10 @@ export default class DocumentReference implements fhir.DocumentReference {
   // this method can be utilised to use all the helper methods provided in class.
   // here we copy the properties from fhir object which are supported in our class.
   public static fromFHIRObject(FHIRObject: fhir.DocumentReference): DocumentReference {
+    console.warn(
+      'DocumentReference.fromFHIRObject: This method will be removed in a future version of the SDK.'
+    );
+
     if (!FHIRObject) {
       throw new Error(
         'DocumentReference.fromFHIRObject requires 1 argument of type fhir DocumentReference.'
@@ -164,7 +168,7 @@ export default class DocumentReference implements fhir.DocumentReference {
   // author can be Practitioner or Organisation
   // TODO handle organisation
   public getAuthor() {
-    const practitionerFhir = getResource(this.author[0], this.contained);
+    const practitionerFhir = this.author?.[0] ? getResource(this.author[0], this.contained) : null;
     return practitionerFhir
       ? (Practitioner.fromFHIRObject(practitionerFhir) as fhir.Practitioner)
       : undefined;

--- a/test/lib/models/fhir/documentReferenceTest.ts
+++ b/test/lib/models/fhir/documentReferenceTest.ts
@@ -129,9 +129,11 @@ describe('models/FHIR', () => {
         // @ts-ignore
         stu3FhirResources.authorlessDocumentReference
       );
+      /* eslint-disable no-unused-expressions */
       expect(convertedDocument.getAuthor()).to.be.undefined;
       expect(convertedDocument.getPractitioner()).to.be.undefined;
       expect(convertedDocument.getPracticeSpecialty()).to.be.undefined;
+      /* eslint-enable no-unused-expressions */
     });
 
     it('should throw error when fromFHIRObject is called with no arguments', done => {

--- a/test/lib/models/fhir/documentReferenceTest.ts
+++ b/test/lib/models/fhir/documentReferenceTest.ts
@@ -123,6 +123,17 @@ describe('models/FHIR', () => {
       );
       expect(documentReference.getType().text).to.equal('Document');
     });
+
+    it('should return undefined for an unset author, practitioner, specialty when not in original resource', () => {
+      const convertedDocument = DocumentReference.fromFHIRObject(
+        // @ts-ignore
+        stu3FhirResources.authorlessDocumentReference
+      );
+      expect(convertedDocument.getAuthor()).to.be.undefined;
+      expect(convertedDocument.getPractitioner()).to.be.undefined;
+      expect(convertedDocument.getPracticeSpecialty()).to.be.undefined;
+    });
+
     it('should throw error when fromFHIRObject is called with no arguments', done => {
       try {
         // @ts-ignore

--- a/test/testUtils/stu3FhirResources.ts
+++ b/test/testUtils/stu3FhirResources.ts
@@ -22,6 +22,47 @@ const stu3FhirResources = {
       },
     ],
   },
+  authorlessDocumentReference: {
+    resourceType: 'DocumentReference',
+    id: '19b45d90-c965-4021-aa15-3dd13c9224e3',
+    status: 'current',
+    content: [
+      {
+        attachment: {
+          id: '8fa3cf2f-2d98-4f0d-a769-1c1ad5107e5d',
+          title: 'v53',
+          contentType: 'image/png',
+          size: 25295,
+          data: 'doesnotreallymaatter',
+          file: {},
+          hash: 'AeuJipYrgLenRjhOo64L6JnyY9E=',
+        },
+      },
+    ],
+    date: '2020-11-04T11:00:00.000Z',
+    type: {
+      coding: [
+        {
+          display: 'Befund',
+        },
+      ],
+    },
+    category: [
+      {
+        coding: [
+          {
+            display: 'Befund',
+          },
+        ],
+      },
+    ],
+    identifier: [
+      {
+        value:
+          'd4l_f_p_t#8fa3cf2f-2d98-4f0d-a769-1c1ad5107e5d#8fa3cf2f-2d98-4f0d-a769-1c1ad5107e5d#8fa3cf2f-2d98-4f0d-a769-1c1ad5107e5d',
+      },
+    ],
+  },
   carePlan: {
     resourceType: 'CarePlan',
     contained: [


### PR DESCRIPTION
### Summary of the issue
This fixes a bug where creating an DocumentReference with a `.fromFhirResource` method where the author was not set would crash. This hardens against the case, returning an undefined author instead. Also notices users that we plan to remove the method at one point.

### Due diligence checklist
- [x] Updated version in package.json if applicable.
- [x] Added/updated tests.
- [x] Add documentation
- [x] If this change affects SDK consumers: communicate changes.


### TODOs
- [ ] Mention any outstanding issues or tasks you need to perform after the merge.
