### PR TITLE
✨ add support for querying by fhir version, including fallback for unencoded version

### DIFF
--- a/docs/sdk.md
+++ b/docs/sdk.md
@@ -577,6 +577,7 @@ Lets you specify options for the `fetchResource` method.
 | start_date | Date |(optional) Earliest date for which to return records |
 | end_date | Date | (optional) Latest date for which to return records |
 | resourceType | String | (optional) Type of requested FHIR resources |
+| fhirVersion | String | (optional) The FHIR verion of the resources, for example "4.0.1" |
 | partner | String | (optional) ID of the partner the records where uploaded from |
 | annotations | String[] | (optional) Custom annotations to filter by
 | exclude_tags | String[] | (optional) Don't fetch resources with given tags

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@d4l/js-sdk",
-  "version": "5.4.0",
+  "version": "5.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@d4l/js-sdk",
-  "version": "5.4.0",
+  "version": "5.5.0",
   "D4L": {
     "data_model_version": 1
   },

--- a/src/lib/taggingUtils.ts
+++ b/src/lib/taggingUtils.ts
@@ -75,6 +75,10 @@ const taggingUtils = {
     );
   },
 
+  buildFallbackTag(key: string, value: string): string {
+    return `${key.toLowerCase()}${TAG_DELIMITER}${value.toLowerCase()}`;
+  },
+
   getTagValueFromList(tagList: string[], tagKey: string): string {
     const clientTag = tagList.find(el => el.startsWith(`${tagKey}${TAG_DELIMITER}`));
     return clientTag ? this.getValue(clientTag) : undefined;

--- a/src/services/appDataService.ts
+++ b/src/services/appDataService.ts
@@ -86,8 +86,10 @@ const appDataService = {
 
   fetchAllAppData(ownerId: string, params: Params = {}): Promise<FetchResponse<AppData>> {
     const parameters = prepareSearchParameters({
-      ...params,
-      tags: [taggingUtils.generateAppDataFlagTag()],
+      params: {
+        ...params,
+        tags: [taggingUtils.generateAppDataFlagTag()],
+      },
     });
 
     return recordService.searchRecords(ownerId, parameters).then(result => ({

--- a/src/services/fhirService.ts
+++ b/src/services/fhirService.ts
@@ -355,7 +355,7 @@ export const prepareSearchParameters = ({
     } else {
       parameters.tags.push(taggingUtils.buildTag(tagKeys.fhirVersion, params.fhirVersion));
     }
-    delete params.fhirVersion;
+    delete parameters.fhirVersion;
   }
 
   if (params.exclude_flags) {
@@ -606,7 +606,9 @@ const fhirService = {
     return recordService.deleteRecord(ownerId, resourceId);
   },
 
-  getSearchCallWithFallbackIfNeeded(
+  /* earlier versions of the Android SDK did not escape the dots in fhir versions,
+    so we query for both of this encoding and the current standard one */
+  searchWithFallbackIfNeeded(
     ownerId: string,
     countOnly: boolean,
     params: Params = {}
@@ -636,7 +638,7 @@ const fhirService = {
   },
 
   countResources(ownerId: string, params: Params = {}): Promise<number> {
-    return this.getSearchCallWithFallbackIfNeeded(ownerId, true, params).then(result =>
+    return this.searchWithFallbackIfNeeded(ownerId, true, params).then(result =>
       result.totalCount
         ? result.totalCount
         : parseInt(result[0].totalCount, 10) + parseInt(result[1].totalCount, 10)
@@ -645,7 +647,7 @@ const fhirService = {
 
   /* eslint-disable indent */
   fetchResources(ownerId: string, params: Params = {}): Promise<FetchResponse<Record>> {
-    return this.getSearchCallWithFallbackIfNeeded(ownerId, false, params).then(response =>
+    return this.searchWithFallbackIfNeeded(ownerId, false, params).then(response =>
       response.records
         ? {
             records: response.records.map(convertToExposedRecord),

--- a/src/services/fhirService.ts
+++ b/src/services/fhirService.ts
@@ -55,7 +55,6 @@ const SUPPORTED_PARAMS = [
   'start_date',
   'end_date',
   'fhirVersion',
-  'fallbackParams',
   'tags',
   'exclude_tags',
   'exclude_flags',

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -2,6 +2,7 @@
 export interface Params {
   limit?: number;
   offset?: number;
+  fhirVersion?: string;
   start_date?: string;
   end_date?: string;
   tags?: string[];

--- a/test/services/fhirServiceTest.ts
+++ b/test/services/fhirServiceTest.ts
@@ -86,7 +86,7 @@ describe('cleanResource', () => {
 
 describe('prepareSearchParameters', () => {
   it('correctly prepares simple parameters', () => {
-    const preparedParams = prepareSearchParameters({ limit: 4, offset: 3 });
+    const preparedParams = prepareSearchParameters({ params: { limit: 4, offset: 3 } });
     expect(preparedParams).to.deep.equal({
       limit: 4,
       offset: 3,
@@ -96,8 +96,10 @@ describe('prepareSearchParameters', () => {
 
   it('correctly prepares simple parameters with a tag', () => {
     const preparedParams = prepareSearchParameters({
-      limit: 10,
-      tags: ['superhero-origin-story'],
+      params: {
+        limit: 10,
+        tags: ['superhero-origin-story'],
+      },
     });
     expect(preparedParams).to.deep.equal({
       limit: 10,
@@ -107,9 +109,11 @@ describe('prepareSearchParameters', () => {
 
   it('correctly prepares simple parameters with a tag and annotation', () => {
     const preparedParams = prepareSearchParameters({
-      limit: 10,
-      tags: ['superhero-origin-story'],
-      annotations: ['an annoation'],
+      params: {
+        limit: 10,
+        tags: ['superhero-origin-story'],
+        annotations: ['an annoation'],
+      },
     });
     expect(preparedParams).to.deep.equal({
       limit: 10,
@@ -119,9 +123,11 @@ describe('prepareSearchParameters', () => {
 
   it('correctly prepares parameters with a tag and a resourceType', () => {
     const preparedParams = prepareSearchParameters({
-      limit: 10,
-      tags: ['superhero-origin-story'],
-      resourceType: 'Patient',
+      params: {
+        limit: 10,
+        tags: ['superhero-origin-story'],
+        resourceType: 'Patient',
+      },
     });
     expect(preparedParams).to.deep.equal({
       limit: 10,
@@ -131,9 +137,11 @@ describe('prepareSearchParameters', () => {
 
   it('correctly prepares parameters with a tag and a partner', () => {
     const preparedParams = prepareSearchParameters({
-      offset: 20,
-      tags: ['superhero-origin-story'],
-      partner: 'S.H.I.E.L.D.',
+      params: {
+        offset: 20,
+        tags: ['superhero-origin-story'],
+        partner: 'S.H.I.E.L.D.',
+      },
     });
     expect(preparedParams).to.deep.equal({
       offset: 20,
@@ -143,8 +151,10 @@ describe('prepareSearchParameters', () => {
 
   it('correctly prepares parameters with exclude_tags', () => {
     const preparedParams = prepareSearchParameters({
-      tags: ['superhero-origin-story'],
-      exclude_tags: ['superman'],
+      params: {
+        tags: ['superhero-origin-story'],
+        exclude_tags: ['superman'],
+      },
     });
     expect(preparedParams).to.deep.equal({
       tags: ['superhero-origin-story'],
@@ -154,8 +164,10 @@ describe('prepareSearchParameters', () => {
 
   it('correctly prepares parameters with exclude_flags', () => {
     const preparedParams = prepareSearchParameters({
-      tags: ['superhero-origin-story'],
-      exclude_flags: [testVariables.appDataFlag],
+      params: {
+        tags: ['superhero-origin-story'],
+        exclude_flags: [testVariables.appDataFlag],
+      },
     });
     expect(preparedParams).to.deep.equal({
       tags: ['superhero-origin-story'],
@@ -165,12 +177,46 @@ describe('prepareSearchParameters', () => {
 
   it('correctly prepares parameters with exclude_tags and exclude_flags', () => {
     const preparedParams = prepareSearchParameters({
-      tags: ['superhero-origin-story'],
-      exclude_tags: ['superman'],
-      exclude_flags: [testVariables.appDataFlag],
+      params: {
+        tags: ['superhero-origin-story'],
+        exclude_tags: ['superman'],
+        exclude_flags: [testVariables.appDataFlag],
+      },
     });
     expect(preparedParams).to.deep.equal({
       tags: ['superhero-origin-story'],
+      exclude_tags: ['custom=superman', testVariables.appDataFlag],
+    });
+  });
+
+  it('correctly prepares a non-fallback fhir version tag', () => {
+    const preparedParams = prepareSearchParameters({
+      params: {
+        tags: ['superhero-origin-story'],
+        exclude_tags: ['superman'],
+        exclude_flags: [testVariables.appDataFlag],
+        fhirVersion: '3.0.1',
+      },
+      useFallbackParams: false,
+    });
+    expect(preparedParams).to.deep.equal({
+      tags: ['superhero-origin-story', 'fhirversion=3%2e0%2e1'],
+      exclude_tags: ['custom=superman', testVariables.appDataFlag],
+    });
+  });
+
+  it('correctly prepares a fallback fhir version tag', () => {
+    const preparedParams = prepareSearchParameters({
+      params: {
+        tags: ['superhero-origin-story'],
+        exclude_tags: ['superman'],
+        exclude_flags: [testVariables.appDataFlag],
+        fhirVersion: '4.0.1',
+      },
+      useFallbackParams: true,
+    });
+    expect(preparedParams).to.deep.equal({
+      tags: ['superhero-origin-story', 'fhirversion=4.0.1'],
       exclude_tags: ['custom=superman', testVariables.appDataFlag],
     });
   });


### PR DESCRIPTION
### Summary of the issue

This adds support for querying the fhirversion of a document directly in fetch/count resources calls. It will be converted to a tag and queried as such, including the legacy format without the %2e encoding of the dots in a version number.

https://gesundheitscloud.atlassian.net/browse/SDK-524

### Due diligence checklist
- [x] Updated version in package.json if applicable.
- [x] Added/updated tests.
- [x] Add documentation
- [ ] If this change affects SDK consumers: communicate changes.


### TODOs
- [ ] Mention any outstanding issues or tasks you need to perform after the merge.
