### PR TITLE
🐛 ✅ SDK-453 fix invalid payload deleting attachments from native apps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@d4l/js-sdk",
-  "version": "5.6.0",
+  "version": "5.6.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@d4l/js-sdk",
-  "version": "5.6.0",
+  "version": "5.6.1",
   "D4L": {
     "data_model_version": 1
   },

--- a/src/lib/attachmentUtils.ts
+++ b/src/lib/attachmentUtils.ts
@@ -4,7 +4,7 @@ import find from 'lodash/find';
 
 import isUndefined from 'lodash/isUndefined';
 import { IBlobFile } from './BlobFile';
-import { getCleanAttachmentsFromResource } from '../services/fhirService';
+import { getCleanAttachmentsFromResource } from '../services/attachmentService';
 
 export const separateOldAndNewAttachments = (newDocumentAttachments, oldDocumentAttachments) =>
   newDocumentAttachments.reduce(

--- a/src/lib/d4lRequest.ts
+++ b/src/lib/d4lRequest.ts
@@ -74,7 +74,7 @@ export function makeRequest(options): Promise<any> {
       }
 
       if (options.body && (options.body.length || Object.keys(options.body).length > 0)) {
-        if (options.headers && options.headers[CONTENT_TYPE] === 'application/octet-stream') {
+        if (options.headers?.[CONTENT_TYPE] === 'application/octet-stream') {
           xhr.send(options.body);
         } else {
           xhr.send(JSON.stringify(options.body));
@@ -163,6 +163,7 @@ const d4lRequest = {
         This needs more refinement on the back-end, or we'll need to send
         these headers more explicitly for specific endpoints only.
         See also https://gesundheitscloud.atlassian.net/browse/CIT-1340
+        and https://gesundheitscloud.atlassian.net/browse/SDK-446
 
         if (this.currentUserLanguage) {
             httpHeaders['X-User-Language'] = this.currentUserLanguage;

--- a/src/lib/models/fhir/DocumentReference.ts
+++ b/src/lib/models/fhir/DocumentReference.ts
@@ -1,4 +1,6 @@
 import find from 'lodash/find';
+import isString from 'lodash/isString';
+import isUndefined from 'lodash/isUndefined';
 import map from 'lodash/map';
 
 import Attachment from './Attachment';
@@ -87,7 +89,7 @@ export default class DocumentReference implements fhir.DocumentReference {
   }: DocumentReferenceConstructor) {
     this.resourceType = DOCUMENT_REFERENCE;
     this.status = 'current';
-    this.type = type;
+    this.type = !isUndefined(type) && !isString(type) ? type : {};
     this.author = [{ reference: '#contained-author-id' }];
     this.description = title;
     this.subject = { reference: title };

--- a/src/services/attachmentService.ts
+++ b/src/services/attachmentService.ts
@@ -1,0 +1,414 @@
+/* eslint-disable no-param-reassign, no-await-in-loop */
+import cloneDeep from 'lodash/cloneDeep';
+import find from 'lodash/find';
+import flatMap from 'lodash/flatMap';
+import includes from 'lodash/includes';
+import isEmpty from 'lodash/isEmpty';
+import isNull from 'lodash/isNull';
+import map from 'lodash/map';
+import merge from 'lodash/merge';
+import mergeWith from 'lodash/mergeWith';
+import omit from 'lodash/omit';
+import reject from 'lodash/reject';
+import some from 'lodash/some';
+import {
+  FULL,
+  getAttachmentIdToDownload,
+  getContentHash,
+  getEncryptedFilesByAttachmentIndex,
+  getFileContentsAsBuffer,
+  getIdentifierValue,
+  hasAttachments,
+  separateOldAndNewAttachments,
+  shrinkImageHeightIfNeeded,
+  verifyAttachmentPayload,
+} from '../lib/attachmentUtils';
+import BlobFile from '../lib/BlobFile';
+import InvalidAttachmentPayloadError from '../lib/errors/InvalidAttachmentPayloadError';
+import ValidationError from '../lib/errors/ValidationError';
+import fhirValidator from '../lib/fhirValidator';
+import {
+  isAllowedByteSequence,
+  isAllowedFileType,
+  isResizableImageByteSequence,
+  isWithinSizeLimit,
+} from '../lib/fileValidator';
+import Attachment from '../lib/models/fhir/Attachment';
+import { DOCUMENT_REFERENCE } from '../lib/models/fhir/DocumentReference';
+import documentRoutes from '../routes/documentRoutes';
+import createCryptoService from './createCryptoService';
+import recordService from './recordService';
+import { DecryptedFhirRecord, FetchResponse, Params, Record } from './types';
+
+type IAttachment = {
+  isImage?: boolean;
+  hasPreview?: boolean;
+  hasThumb?: boolean;
+  id?: string;
+};
+
+// TODO: Add return Type
+/*
+ * This is preliminary work based on the idea that the SDK should be able to handle
+ * attachments for all the resources it supports, not just for DocumentReference
+ * resources. However, while these methods return the proper attachment structures,
+ * there is not support for a generic upload/download mechanism in the fhirService's
+ * actual CRUD methods.
+ *
+ * */
+export const getCleanAttachmentsFromResource = (resource: any): any[] => {
+  const { resourceType } = resource;
+
+  let attachments;
+  if (resourceType === 'DocumentReference') {
+    attachments = map(resource.content, 'attachment');
+  }
+  if (resourceType === 'Patient' || resourceType === 'Practitioner') {
+    attachments = cloneDeep(resource.photo);
+  }
+  if (resourceType === 'Medication') {
+    attachments = cloneDeep(resource.image);
+  }
+  if (resourceType === 'DiagnosticReport') {
+    attachments = cloneDeep(resource.presentedForm);
+  }
+  if (resourceType === 'Observation') {
+    const components = [...(resource.component || [])];
+    attachments = reject(
+      [
+        ...[resource.valueAttachment || []],
+        // @ts-ignore
+        ...map(components, 'valueAttachment'),
+      ],
+      isEmpty
+    );
+  }
+  if (resourceType === 'Questionnaire') {
+    const initialAttachments = map(resource.item, 'initialAttachment');
+    attachments = initialAttachments.length ? reject(initialAttachments, isEmpty) : [];
+  }
+
+  if (resourceType === 'QuestionnaireResponse') {
+    const answers = flatMap(resource.item, 'answer');
+    attachments = answers.length ? reject(map(answers, 'valueAttachment'), isEmpty) : [];
+  }
+
+  if (!attachments || !attachments.length) {
+    return [];
+  }
+
+  return attachments.map((attachment: any) => {
+    if (attachment.originalSize && attachment.originalHash) {
+      attachment.size = attachment.originalSize;
+      delete attachment.originalSize;
+      attachment.hash = attachment.originalHash;
+      delete attachment.originalHash;
+    }
+    return attachment;
+  });
+};
+
+export const setAttachmentsToResource = (
+  resourceWithoutAttachments: fhir.DomainResource,
+  attachments: Attachment[]
+): fhir.DomainResource => {
+  const resource = cloneDeep(resourceWithoutAttachments);
+  const { resourceType } = resource;
+
+  if (resourceType === 'DocumentReference') {
+    (resource as fhir.DocumentReference).content = attachments.map(attachment => ({ attachment }));
+  }
+  if (resourceType === 'Patient') {
+    (resource as fhir.Patient).photo = [...attachments];
+  }
+  if (resourceType === 'Practitioner') {
+    (resource as fhir.Practitioner).photo = [...attachments];
+  }
+  if (resourceType === 'Medication') {
+    (resource as fhir.Medication).image = [...attachments];
+  }
+  if (resourceType === 'DiagnosticReport') {
+    (resource as fhir.DiagnosticReport).presentedForm = [...attachments];
+  }
+
+  if (resourceType === 'Observation') {
+    const components = (resource as fhir.Observation).component;
+    if (components && components.length) {
+      components.forEach(component => {
+        if (!isEmpty(component.valueAttachment)) {
+          const { hash = null, id = null } = component.valueAttachment;
+          const matchByHash = find(attachments, { hash });
+          const matchById = find(attachments, { id });
+          if (matchByHash && !matchById) {
+            component.valueAttachment = matchByHash;
+          }
+        }
+      });
+    }
+  }
+  if (resourceType === 'Questionnaire') {
+    const items = (resource as fhir.Questionnaire).item;
+    if (items && items.length) {
+      items.forEach(item => {
+        if (!isEmpty(item.initialAttachment)) {
+          const { hash = null, id = null } = item.initialAttachment;
+          const matchByHash = find(attachments, { hash });
+          const matchById = find(attachments, { id });
+          if (matchByHash && !matchById) {
+            item.initialAttachment = matchByHash;
+          }
+        }
+      });
+    }
+  }
+
+  /*
+   * This one is a little more tricky because of the deep nesting.
+   *
+   * Essentially what we do is find a content (hash) match in
+   * item.answer.valueAttachment, and if it has id declare it as old
+   *
+   * */
+  if (resourceType === 'QuestionnaireResponse') {
+    const items = (resource as fhir.QuestionnaireResponse).item;
+    if (items && items.length) {
+      items.forEach(item => {
+        const answers = item.answer;
+        if (answers && answers.length) {
+          answers.forEach(answer => {
+            if (!isEmpty(answer.valueAttachment)) {
+              const { hash = null, id = null } = answer.valueAttachment;
+              const matchByHash = find(attachments, { hash });
+              const matchById = find(attachments, { id });
+              if (matchByHash && !matchById) {
+                answer.valueAttachment = matchByHash;
+              }
+            }
+          });
+        }
+      });
+    }
+  }
+
+  return resource;
+};
+
+export const addPreviewsToAttachments = async vanillaAttachments => {
+  const blobs = [];
+  const attachmentsWithPreviews = cloneDeep(vanillaAttachments);
+  // why are we not using a .map or .forEach?
+  // Because they are not executed in the expected manner with async functions/promises
+  // eslint-disable-next-line no-restricted-syntax
+  for (const attachment of attachmentsWithPreviews) {
+    const { file, title } = attachment;
+    if (!isWithinSizeLimit(file)) {
+      throw new Error('File is too large.');
+    }
+
+    if (!(await isAllowedFileType(file))) {
+      throw new Error('Tried to uploaded unsupported file type');
+    }
+
+    const content = await getFileContentsAsBuffer(file);
+    blobs.push(file);
+
+    if (isResizableImageByteSequence(new Uint8Array(content as ArrayBuffer))) {
+      Object.assign(attachment, {
+        isImage: true,
+        hasThumb: false,
+        hasPreview: false,
+      });
+
+      const thumb = await shrinkImageHeightIfNeeded(title, file, 200);
+      if (!isNull(thumb)) {
+        // this is nested here because if there's no thumb, the image is <= 200px
+        // in which case there will definitely not be a dedicated preview either.
+        const preview = await shrinkImageHeightIfNeeded(title, file, 1000);
+        if (!isNull(preview)) {
+          attachment.hasPreview = true;
+          blobs.push(preview);
+        }
+
+        attachment.hasThumb = true;
+        blobs.push(thumb);
+      }
+    }
+  }
+  return [blobs, attachmentsWithPreviews];
+};
+
+const uploadAttachments = (ownerId, encryptedFiles) =>
+  Promise.all(encryptedFiles.map(file => documentRoutes.uploadDocument(ownerId, file)));
+
+export const cleanResource = (fhirResource: fhir.DomainResource) => {
+  if (fhirResource.resourceType === DOCUMENT_REFERENCE) {
+    // @ts-ignore
+    if (fhirResource.content) {
+      const clonedResource = cloneDeep(fhirResource);
+      // @ts-ignore
+      clonedResource.content = fhirResource.content.map(value => omit(value, 'attachment.file'));
+      return clonedResource;
+    }
+  }
+
+  return fhirResource;
+};
+
+export const attachBlobs = ({
+  encryptedFiles,
+  ownerId,
+  oldAttachments = [],
+  newAttachments,
+  resource,
+}: {
+  encryptedFiles: Uint8Array[];
+  ownerId: string;
+  oldAttachments: File[];
+  newAttachments: IAttachment[];
+  resource: fhir.DomainResource;
+}) => {
+  const uploadPromises = newAttachments.map((_, index) =>
+    uploadAttachments(
+      ownerId,
+      getEncryptedFilesByAttachmentIndex(encryptedFiles, newAttachments, index)
+    )
+  );
+
+  return Promise.all(uploadPromises).then(uploadInformation => {
+    // @ts-ignore
+    const identifier = resource.identifier || [];
+    newAttachments.forEach((attachment, attachmentIndex) => {
+      // @ts-ignore
+      attachment.id = uploadInformation[attachmentIndex][0].document_id;
+      identifier.push(getIdentifierValue(uploadInformation[attachmentIndex]));
+    });
+
+    const attachments = [
+      ...oldAttachments,
+      ...map(newAttachments, item => omit(item, ['isImage', 'hasPreview', 'hasThumb'])),
+    ];
+
+    const attachmentsWithoutFiles = map(attachments, item => omit(item, 'file'));
+
+    const returnResource = setAttachmentsToResource(resource, attachments as Attachment[]);
+    const resourceWithAttachments = setAttachmentsToResource(
+      resource,
+      attachmentsWithoutFiles as Attachment[]
+    );
+
+    // @ts-ignore
+    resourceWithAttachments.identifier = identifier;
+    // @ts-ignore
+    returnResource.identifier = identifier;
+
+    return [resourceWithAttachments, returnResource];
+  });
+};
+
+const attachmentService = {
+  async handleAttachments(ownerId: string, resource: fhir.DomainResource) {
+    const attachments = getCleanAttachmentsFromResource(resource);
+    const attachmentFiles = map(attachments, 'file');
+
+    // @ts-ignore
+    return Promise.all(attachmentFiles.map(getContentHash))
+      .then(async hashes => {
+        const metaInformation = mergeWith(hashes, attachments, (hash, attachmentFile) => ({
+          hash,
+          size: attachmentFile.file.size,
+        }));
+
+        const newAttachments = merge(attachments, metaInformation);
+        const [blobs, newAttachmentsWithPreviews] = await addPreviewsToAttachments(newAttachments);
+
+        const [encryptedFiles, updatedKeyInfo] = await createCryptoService(ownerId).encryptBlobs(
+          blobs
+        );
+
+        const [originalResource, returnResource] = await attachBlobs({
+          ownerId,
+          resource,
+          newAttachments: newAttachmentsWithPreviews,
+          oldAttachments: [],
+          encryptedFiles: encryptedFiles as Uint8Array[],
+        });
+        return [originalResource, returnResource, updatedKeyInfo];
+      })
+      .catch(() => {
+        return Promise.reject(new Error('Creating the Resource failed'));
+      });
+  },
+
+  updateAttachments(ownerId: string, resource: fhir.DomainResource, annotations: string[]) {
+    return recordService
+      .downloadRecord(ownerId, resource.id)
+      .then((previousRecord: DecryptedFhirRecord) => {
+        const previousResource = previousRecord.fhirResource;
+        const previousAttachments = getCleanAttachmentsFromResource(previousResource);
+
+        const currentAttachments = getCleanAttachmentsFromResource(resource);
+        const currentAttachmentFiles = map(currentAttachments, 'file');
+
+        const notAllFilesDownloaded = some(currentAttachmentFiles, file => !(file instanceof File));
+
+        const isTagUpdateWithoutAttachmentContent =
+          notAllFilesDownloaded && previousAttachments.length === currentAttachments.length;
+
+        if (isTagUpdateWithoutAttachmentContent && annotations.length > 0) {
+          const returnResource = cloneDeep(resource);
+          const attachmentsWithoutFiles = map(
+            getCleanAttachmentsFromResource(resource),
+            attachment => omit(attachment, 'file')
+          );
+          setAttachmentsToResource(resource, attachmentsWithoutFiles as Attachment[]);
+
+          return [previousRecord.attachmentKey, resource, returnResource];
+        }
+
+        return Promise.all(currentAttachmentFiles.map(getContentHash))
+          .then(async hashes => {
+            const metaInformation = mergeWith(
+              hashes,
+              currentAttachments,
+              (hash, attachmentFile) => ({
+                hash,
+                size: attachmentFile.file.size,
+              })
+            );
+
+            const currentAttachmentsWithMeta = merge(currentAttachments, metaInformation);
+            const [oldAttachments, newAttachments] = separateOldAndNewAttachments(
+              currentAttachmentsWithMeta,
+              previousAttachments
+            );
+
+            const [blobs, newAttachmentsWithPreviews] = await addPreviewsToAttachments(
+              newAttachments
+            );
+
+            const [encryptedFiles, updatedKeyInfo] = await createCryptoService(
+              ownerId
+            ).encryptBlobs(blobs, previousRecord.attachmentKey);
+
+            // @ts-ignore
+            resource.identifier = previousResource.identifier;
+
+            const [originalResource, returnResource] = await attachBlobs({
+              ownerId,
+              oldAttachments,
+              // @ts-ignore
+              resource,
+              newAttachments: newAttachmentsWithPreviews,
+              encryptedFiles: encryptedFiles as Uint8Array[],
+            });
+
+            return [updatedKeyInfo, originalResource, returnResource];
+          })
+          .catch(() => {
+            return Promise.reject(new Error('Updating the Resource failed'));
+          });
+      });
+  },
+};
+
+export default attachmentService;

--- a/src/services/fhirService.ts
+++ b/src/services/fhirService.ts
@@ -64,6 +64,14 @@ const SUPPORTED_PARAMS = [
 ];
 
 // TODO: Add return Type
+/*
+ * This is preliminary work based on the idea that the SDK should be able to handle
+ * attachments for all the resources it supports, not just for DocumentReference
+ * resources. However, while these methods return the proper attachment structures,
+ * there is not support for a generic upload/download mechanism in the fhirService's
+ * actual CRUD methods.
+ *
+ * */
 export const getCleanAttachmentsFromResource = (resource: any): any[] => {
   const { resourceType } = resource;
 
@@ -371,6 +379,7 @@ export const prepareSearchParameters = ({
   return parameters;
 };
 
+// todo: write test for this
 const convertToExposedRecord = (decryptedRecord: DecryptedFhirRecord) => {
   const exposedRecord = {
     annotations: taggingUtils.getAnnotations(decryptedRecord.tags),

--- a/src/services/userService.ts
+++ b/src/services/userService.ts
@@ -114,8 +114,8 @@ const userService = {
   /**
    * Get the user for an id.
    *  @param userId Id of the user whos data is requested.
-   *                Loggedin user by default(even if `this.currentUserId` is not set yet).
-   * @returns Resolves to a userObject that contains `userId`, `commonKey` and `tagEncryptionKey`.
+   *                Logged-in user by default (even if 'this.currentUserId' is not set yet).
+   * @returns Resolves to a userObject that contains 'userId', 'commonKey' and 'tagEncryptionKey'.
    */
   pullUser(userId?: string): Promise<User> {
     // Does not work, if this.privateKey is not set.

--- a/test/lib/models/fhir/documentReferenceTest.ts
+++ b/test/lib/models/fhir/documentReferenceTest.ts
@@ -70,7 +70,7 @@ describe('models/FHIR', () => {
         title: 'John Doe Document',
       });
       expect(documentReference.getTitle()).to.equal('John Doe Document');
-      expect(documentReference.getType()).to.equal(undefined);
+      expect(JSON.stringify(documentReference.getType())).to.equal(JSON.stringify({}));
       expect(documentReference.getPracticeSpecialty()).to.equal(undefined);
       expect(documentReference.getAuthor()).to.equal(undefined);
       expect(documentReference.getPractitioner()).to.equal(undefined);

--- a/test/services/attachmentServiceTest.ts
+++ b/test/services/attachmentServiceTest.ts
@@ -1,0 +1,586 @@
+/* eslint-env mocha */
+/* eslint-disable no-unused-expressions */
+/* eslint-disable max-nested-callbacks */
+import 'babel-polyfill';
+import chai from 'chai';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+import {
+  attachBlobs,
+  setAttachmentsToResource,
+  getCleanAttachmentsFromResource,
+  cleanResource,
+} from '../../src/services/attachmentService';
+import testVariables from '../testUtils/testVariables';
+import stu3FhirResources from '../testUtils/stu3FhirResources';
+import { D4LSDK } from '../../src/d4l';
+import documentRoutes from '../../src/routes/documentRoutes';
+import DocumentReference, { DOCUMENT_REFERENCE } from '../../src/lib/models/fhir/DocumentReference';
+
+chai.use(sinonChai);
+
+const { expect } = chai;
+
+describe('cleanResource', () => {
+  it('works on a mutable documentReference', () => {
+    const resource = {
+      resourceType: DOCUMENT_REFERENCE,
+      content: [
+        {
+          attachment: {
+            file: 'Pretend this is a file to be deleted',
+            anotherProperty: 'I should survive this operation',
+          },
+        },
+      ],
+    };
+    const cleanedResource = cleanResource(resource);
+    // @ts-ignore
+    expect(cleanedResource.content[0].attachment.file).to.be.undefined;
+    // @ts-ignore
+    expect(cleanedResource.content[0].attachment.anotherProperty).to.equal(
+      'I should survive this operation'
+    );
+    expect(resource.content[0].attachment.file).not.to.be.undefined;
+    expect(resource.content[0].attachment.anotherProperty).to.equal(
+      'I should survive this operation'
+    );
+  });
+
+  it('works on an immutable documentReference', () => {
+    const resource = {
+      resourceType: DOCUMENT_REFERENCE,
+    };
+
+    Object.defineProperty(resource, 'content', {
+      value: [
+        {
+          attachment: {
+            file: 'Pretend this is a file to be deleted',
+            anotherProperty: 'I should survive this operation',
+          },
+        },
+      ],
+      configurable: false,
+      writable: false,
+    });
+    const cleanedResource = cleanResource(resource);
+    // @ts-ignore
+    expect(cleanedResource.content[0].attachment.file).to.be.undefined;
+    // @ts-ignore
+    expect(cleanedResource.content[0].attachment.anotherProperty).to.equal(
+      'I should survive this operation'
+    );
+    // @ts-ignore
+    expect(resource.content[0].attachment.file).not.to.be.undefined;
+    // @ts-ignore
+    expect(resource.content[0].attachment.anotherProperty).to.equal(
+      'I should survive this operation'
+    );
+  });
+});
+
+describe('setAttachmentsToResource', () => {
+  const attachments = [{ image: 'simpleImage' }, { document: 'pdf' }];
+  it('should return a DocumentReference with Attachments set', () => {
+    const documentReference = {
+      resourceType: 'DocumentReference',
+    };
+    const originalDocumentReference = JSON.parse(JSON.stringify(documentReference));
+    // @ts-ignore
+    const updatedDocumentReference = setAttachmentsToResource(documentReference, attachments);
+    expect(updatedDocumentReference).to.deep.equal({
+      resourceType: 'DocumentReference',
+      content: [{ attachment: { image: 'simpleImage' } }, { attachment: { document: 'pdf' } }],
+    });
+    expect(documentReference).to.deep.equal(originalDocumentReference);
+  });
+
+  it('should return the DocumentReference given, when attachments is an empty array', () => {
+    const documentReference = {
+      resourceType: 'DocumentReference',
+    };
+
+    const updatedDocumentReference = setAttachmentsToResource(documentReference, []);
+    expect(updatedDocumentReference).to.deep.equal({
+      resourceType: 'DocumentReference',
+      content: [],
+    });
+    expect(documentReference).to.deep.equal({ resourceType: 'DocumentReference' });
+  });
+
+  it('should return a Patient with Attachments set', () => {
+    const patient = {
+      resourceType: 'Patient',
+    };
+    const originalPatient = JSON.parse(JSON.stringify(patient));
+    // @ts-ignore
+    const updatedPatient = setAttachmentsToResource(patient, attachments);
+    expect(updatedPatient).to.deep.equal({
+      resourceType: 'Patient',
+      photo: [{ image: 'simpleImage' }, { document: 'pdf' }],
+    });
+    expect(patient).to.deep.equal(originalPatient);
+  });
+
+  it('should return a Practitioner with Attachments set', () => {
+    const practitioner = {
+      resourceType: 'Practitioner',
+    };
+    const originalPractitioner = JSON.parse(JSON.stringify(practitioner));
+    // @ts-ignore
+    const updatedPractitioner = setAttachmentsToResource(practitioner, attachments);
+    expect(updatedPractitioner).to.deep.equal({
+      resourceType: 'Practitioner',
+      photo: [{ image: 'simpleImage' }, { document: 'pdf' }],
+    });
+    expect(practitioner).to.deep.equal(originalPractitioner);
+  });
+
+  it('should return a Medication with Attachments set', () => {
+    const medication = {
+      resourceType: 'Medication',
+    };
+    const originalMedication = JSON.parse(JSON.stringify(medication));
+    // @ts-ignore
+    const updatedPractitioner = setAttachmentsToResource(medication, attachments);
+    expect(updatedPractitioner).to.deep.equal({
+      resourceType: 'Medication',
+      image: [{ image: 'simpleImage' }, { document: 'pdf' }],
+    });
+    expect(medication).to.deep.equal(originalMedication);
+  });
+
+  it('should return a DiagnosticReport with Attachments set', () => {
+    const diagnosticReport = {
+      resourceType: 'DiagnosticReport',
+    };
+    const originalDiagnosticReport = JSON.parse(JSON.stringify(diagnosticReport));
+    // @ts-ignore
+    const updatedDiagnosticReport = setAttachmentsToResource(diagnosticReport, attachments);
+    expect(updatedDiagnosticReport).to.deep.equal({
+      resourceType: 'DiagnosticReport',
+      presentedForm: [{ image: 'simpleImage' }, { document: 'pdf' }],
+    });
+    expect(diagnosticReport).to.deep.equal(originalDiagnosticReport);
+  });
+});
+
+describe('getAttachmentsFromResource', () => {
+  it('should return the Attachments of a DocumentReference', () => {
+    const documentReference = {
+      resourceType: 'DocumentReference',
+      content: [{ attachment: { image: 'simpleImage' } }, { attachment: { document: 'pdf' } }],
+    };
+    const attachments = getCleanAttachmentsFromResource(documentReference);
+    expect(attachments).to.deep.equal([{ image: 'simpleImage' }, { document: 'pdf' }]);
+  });
+
+  it('should return an empty array when content is not set on DocumentReference', () => {
+    const documentReference = {};
+    const attachments = getCleanAttachmentsFromResource(documentReference);
+    expect(documentReference).to.deep.equal({});
+    expect(attachments).to.deep.equal([]);
+  });
+
+  it('should return the Attachments of a Patient', () => {
+    const patient = {
+      resourceType: 'Patient',
+      photo: [{ image: 'simpleImage' }, { document: 'pdf' }],
+    };
+    const attachments = getCleanAttachmentsFromResource(patient);
+    expect(attachments).to.deep.equal([{ image: 'simpleImage' }, { document: 'pdf' }]);
+  });
+
+  it('should return the Attachments of a Practitioner', () => {
+    const practitioner = {
+      resourceType: 'Practitioner',
+      photo: [{ image: 'simpleImage' }, { document: 'pdf' }],
+    };
+    const attachments = getCleanAttachmentsFromResource(practitioner);
+    expect(attachments).to.deep.equal([{ image: 'simpleImage' }, { document: 'pdf' }]);
+  });
+
+  it('should return the Attachments of a Medication', () => {
+    const medication = {
+      resourceType: 'Medication',
+      image: [{ image: 'simpleImage' }, { document: 'pdf' }],
+    };
+    const attachments = getCleanAttachmentsFromResource(medication);
+    expect(attachments).to.deep.equal([{ image: 'simpleImage' }, { document: 'pdf' }]);
+  });
+
+  it('should return the Attachments of a DiagnosticReport', () => {
+    const diagnosticReport = {
+      resourceType: 'DiagnosticReport',
+      presentedForm: [{ image: 'simpleImage' }, { document: 'pdf' }],
+    };
+    const attachments = getCleanAttachmentsFromResource(diagnosticReport);
+    expect(attachments).to.deep.equal([{ image: 'simpleImage' }, { document: 'pdf' }]);
+  });
+
+  it('should return the Attachments of an Observation with a component and a valueAttachment', () => {
+    const practitioner = {
+      resourceType: 'Observation',
+      valueAttachment: { image: 'simpleImage' },
+      component: [{ valueAttachment: { document: 'pdf' } }],
+    };
+    const attachments = getCleanAttachmentsFromResource(practitioner);
+    expect(attachments).to.deep.equal([{ image: 'simpleImage' }, { document: 'pdf' }]);
+  });
+
+  it('should return the Attachments of an Observation with only a component attachment', () => {
+    const practitioner = {
+      resourceType: 'Observation',
+      component: [
+        { valueAttachment: { image: 'simpleImage' } },
+        { valueString: 'i am string' },
+        { valueAttachment: { document: 'pdf' } },
+      ],
+    };
+    const attachments = getCleanAttachmentsFromResource(practitioner);
+    expect(attachments).to.deep.equal([{ image: 'simpleImage' }, { document: 'pdf' }]);
+  });
+
+  it('should return the Attachments of an Observation with only a valueAttachment', () => {
+    const practitioner = {
+      resourceType: 'Observation',
+      valueAttachment: { image: 'simpleImage' },
+    };
+    const attachments = getCleanAttachmentsFromResource(practitioner);
+    expect(attachments).to.deep.equal([{ image: 'simpleImage' }]);
+  });
+
+  it('should return no attachments of an Observation with no valueAttachment and no component-based attachments', () => {
+    const practitioner = {
+      resourceType: 'Observation',
+    };
+    const attachments = getCleanAttachmentsFromResource(practitioner);
+    expect(attachments).to.deep.equal([]);
+  });
+
+  it('should return the Attachments of a Questionnaire', () => {
+    const questionnaire = {
+      resourceType: 'Questionnaire',
+      item: [{ initialAttachment: { document: 'pdf' } }],
+    };
+    const attachments = getCleanAttachmentsFromResource(questionnaire);
+    expect(attachments).to.deep.equal([{ document: 'pdf' }]);
+  });
+
+  it('should not return the non-existent attachments of a Questionnaire', () => {
+    const questionnaire = {
+      resourceType: 'Questionnaire',
+      item: [{ initialString: 'i am a string' }],
+    };
+    const attachments = getCleanAttachmentsFromResource(questionnaire);
+    expect(attachments).to.deep.equal([]);
+  });
+
+  it('should return the Attachments of a QuestionnaireResponse', () => {
+    const questionnaire = {
+      resourceType: 'QuestionnaireResponse',
+      item: [
+        {
+          answer: [
+            { valueAttachment: { document: 'pdf' } },
+            { valueString: 'still just a string' },
+          ],
+        },
+        {
+          answer: [{ valueAttachment: { image: 'simpleImage' } }],
+        },
+      ],
+    };
+    const attachments = getCleanAttachmentsFromResource(questionnaire);
+    expect(attachments).to.deep.equal([{ document: 'pdf' }, { image: 'simpleImage' }]);
+  });
+
+  it('should return an empty array for QuestionnaireResponse with no valueAttachments', () => {
+    const questionnaire = {
+      resourceType: 'QuestionnaireResponse',
+      item: [
+        {
+          answer: [{ valueString: 'still just a string' }],
+        },
+      ],
+    };
+    const attachments = getCleanAttachmentsFromResource(questionnaire);
+    expect(attachments).to.deep.equal([]);
+  });
+});
+
+describe('attachBlobs', () => {
+  let uploadDocumentStub;
+  const mockPdfBlob = new Uint8Array([0x25, 0x50, 0x44, 0x46, 0x2d]);
+  const mockPngBlob = new Uint8Array([0x89, 0x50, 0x4e, 0x47]);
+
+  beforeEach(() => {
+    uploadDocumentStub = sinon
+      .stub(documentRoutes, 'uploadDocument')
+      .returns(Promise.resolve({ document_id: 'document_id' }));
+  });
+
+  afterEach(() => {
+    uploadDocumentStub.restore();
+  });
+
+  it('correctly attaches a single non-image', done => {
+    fetch('/fileSamples/sample.pdf')
+      .then(res => res.blob())
+      .then(resAsFile => {
+        const newAttachment = {
+          file: resAsFile, // not that the actual image matters, all based on props
+          title: 'not a doctor',
+        };
+
+        // technically not encrypted at this point
+        const encryptedFiles = [mockPdfBlob];
+        return attachBlobs({
+          encryptedFiles,
+          ownerId: testVariables.userId,
+          oldAttachments: [],
+          // @ts-ignore
+          newAttachments: [newAttachment],
+          // @ts-ignore
+          resource: new D4LSDK.models.DocumentReference(stu3FhirResources.documentReference),
+        });
+      })
+      .then(([resource, returnResource]) => {
+        // @ts-ignore
+        const uploadAttachments = resource.getAttachments();
+        // @ts-ignore
+        const returnAttachments = returnResource.getAttachments();
+        expect(uploadDocumentStub).to.be.calledOnce;
+        expect(uploadAttachments.length).to.equal(returnAttachments.length);
+        expect(uploadAttachments[0].file).to.be.undefined;
+        expect(returnAttachments[0].file).to.not.be.undefined;
+        expect(returnAttachments[0].file instanceof Blob).to.be.true;
+      })
+      .then(done)
+      .catch(done);
+  });
+
+  it('correctly attaches a single image with preview and thumbnail', done => {
+    fetch('/fileSamples/sample.png')
+      .then(res => res.blob())
+      .then(resAsFile => {
+        const newAttachment = {
+          file: resAsFile, // not that the actual image matters, all based on props
+          title: 'not a doctor',
+          isImage: true,
+          hasPreview: true,
+          hasThumb: true,
+        };
+
+        // technically not encrypted at this point
+        const encryptedFiles = [mockPngBlob, mockPngBlob, mockPngBlob];
+        return attachBlobs({
+          encryptedFiles,
+          ownerId: testVariables.userId,
+          oldAttachments: [],
+          newAttachments: [newAttachment],
+          // @ts-ignore
+          resource: new D4LSDK.models.DocumentReference(stu3FhirResources.documentReference),
+        });
+      })
+      .then(([resource, returnResource]) => {
+        // @ts-ignore
+        const uploadAttachments = resource.getAttachments();
+        // @ts-ignore
+        const returnAttachments = returnResource.getAttachments();
+        expect(uploadDocumentStub).to.be.calledThrice;
+        expect(uploadAttachments.length).to.equal(returnAttachments.length);
+        expect(uploadAttachments[0].file).to.be.undefined;
+        expect(returnAttachments[0].file).to.not.be.undefined;
+        // @ts-ignore
+        expect(returnResource.identifier).to.not.be.undefined;
+        expect(returnAttachments[0].file instanceof Blob).to.be.true;
+      })
+      .then(done)
+      .catch(done);
+  });
+
+  it('correctly attaches a single image with just a thumbnail', done => {
+    let attachment;
+    fetch('/fileSamples/sample.png')
+      .then(res => res.blob())
+      .then(resAsFile => {
+        attachment = {
+          file: resAsFile, // not that the actual image matters, all based on props
+          title: 'not a doctor',
+          isImage: true,
+          hasThumb: true,
+        };
+
+        // technically not encrypted at this point
+        const encryptedFiles = [mockPngBlob, mockPngBlob];
+        return attachBlobs({
+          encryptedFiles,
+          ownerId: testVariables.userId,
+          oldAttachments: [],
+          newAttachments: [attachment],
+          // @ts-ignore
+          resource: new D4LSDK.models.DocumentReference(stu3FhirResources.documentReference),
+        });
+      })
+      .then(([resource, returnResource]) => {
+        // @ts-ignore
+        const uploadAttachments = resource.getAttachments();
+        // @ts-ignore
+        const returnAttachments = returnResource.getAttachments();
+        expect(uploadDocumentStub).to.be.calledTwice;
+        expect(uploadAttachments.length).to.equal(returnAttachments.length);
+        expect(uploadAttachments[0].file).to.be.undefined;
+        expect(returnAttachments[0].file).to.not.be.undefined;
+        // @ts-ignore
+        expect(returnResource.identifier).to.not.be.undefined;
+        expect(returnAttachments[0].file instanceof Blob).to.be.true;
+      })
+      .then(done)
+      .catch(done);
+  });
+
+  it('correctly attaches a single image with no thumbnail or preview', done => {
+    let attachment;
+    fetch('/fileSamples/sample.png')
+      .then(res => res.blob())
+      .then(resAsFile => {
+        attachment = {
+          file: resAsFile, // not that the actual image matters, all based on props
+          title: 'not a doctor',
+          isImage: true,
+        };
+
+        // technically not encrypted at this point
+        const encryptedFiles = [mockPngBlob];
+        return attachBlobs({
+          encryptedFiles,
+          ownerId: testVariables.userId,
+          oldAttachments: [],
+          newAttachments: [attachment],
+          // @ts-ignore
+          resource: new D4LSDK.models.DocumentReference(stu3FhirResources.documentReference),
+        });
+      })
+      .then(([resource, returnResource]) => {
+        // @ts-ignore
+        const uploadAttachments = resource.getAttachments();
+        // @ts-ignore
+        const returnAttachments = returnResource.getAttachments();
+        expect(uploadDocumentStub).to.be.calledOnce;
+        expect(uploadAttachments.length).to.equal(returnAttachments.length);
+        expect(uploadAttachments[0].file).to.be.undefined;
+        expect(returnAttachments[0].file).to.not.be.undefined;
+        // @ts-ignore
+        expect(returnResource.identifier).to.not.be.undefined;
+        expect(returnAttachments[0].file instanceof Blob).to.be.true;
+      })
+      .then(done)
+      .catch(done);
+  });
+
+  it('adds a second attachment but keeps the old one intact', done => {
+    fetch('/fileSamples/sample.pdf')
+      .then(res => res.blob())
+      .then(resAsFile => {
+        const newAttachment = {
+          file: resAsFile, // not that the actual image matters, all based on props
+          title: 'not a doctor',
+        };
+        const oldAttachment = {
+          file: resAsFile, // not that the actual image matters, all based on props
+          title: 'old attachment',
+        };
+
+        // technically not encrypted at this point
+        const encryptedFiles = [mockPdfBlob];
+        // @ts-ignore
+        const resource = new D4LSDK.models.DocumentReference(stu3FhirResources.documentReference);
+        resource.setAttachments([oldAttachment]);
+
+        return attachBlobs({
+          resource,
+          encryptedFiles,
+          ownerId: testVariables.userId,
+          // @ts-ignore
+          oldAttachments: [oldAttachment],
+          // @ts-ignore
+          newAttachments: [newAttachment],
+        });
+      })
+      .then(([resource, returnResource]) => {
+        // @ts-ignore
+        const uploadAttachments = resource.getAttachments();
+        // @ts-ignore
+        const returnAttachments = returnResource.getAttachments();
+        expect(uploadDocumentStub).to.be.calledOnce;
+        expect(uploadAttachments.length).to.equal(returnAttachments.length);
+        expect(uploadAttachments.length).to.equal(2);
+        expect(uploadAttachments[0].file).to.be.undefined;
+        expect(returnAttachments[0].file).to.not.be.undefined;
+        // @ts-ignore
+        expect(returnResource.identifier).to.not.be.undefined;
+        expect(returnAttachments[0].file instanceof Blob).to.be.true;
+        expect(returnAttachments[1].file instanceof Blob).to.be.true;
+      })
+      .then(done)
+      .catch(done);
+  });
+
+  it('works as expected with a document with one existing attachment and new ones', done => {
+    fetch('/fileSamples/sample.pdf')
+      .then(res => res.blob())
+      .then(resAsFile => {
+        const newAttachment1 = {
+          file: resAsFile,
+          title: 'not a doctor',
+          isImage: true,
+          hasPreview: true,
+          hasThumb: true,
+        };
+        const newAttachment2 = {
+          file: resAsFile,
+          title: 'fermulon',
+        };
+        const oldAttachment = {
+          file: resAsFile,
+          title: 'old attachment',
+        };
+
+        // technically not encrypted at this point
+        const encryptedFiles = [mockPngBlob, mockPngBlob, mockPngBlob, mockPdfBlob];
+        // @ts-ignore
+        const resource = new D4LSDK.models.DocumentReference(stu3FhirResources.documentReference);
+        resource.setAttachments([oldAttachment]);
+
+        return attachBlobs({
+          resource,
+          encryptedFiles,
+          ownerId: testVariables.userId,
+          // @ts-ignore
+          oldAttachments: [oldAttachment],
+          // @ts-ignore
+          newAttachments: [newAttachment1, newAttachment2],
+        });
+      })
+      .then(([resource, returnResource]) => {
+        // @ts-ignore
+        const uploadAttachments = resource.getAttachments();
+        // @ts-ignore
+        const returnAttachments = returnResource.getAttachments();
+        expect(uploadDocumentStub.callCount).to.equal(4);
+        expect(uploadAttachments.length).to.equal(returnAttachments.length);
+        expect(uploadAttachments.length).to.equal(3);
+        expect(uploadAttachments[0].file).to.be.undefined;
+        expect(returnAttachments[0].file).to.not.be.undefined;
+        // @ts-ignore
+        expect(returnResource.identifier).to.not.be.undefined;
+        expect(returnAttachments[0].file instanceof Blob).to.be.true;
+        expect(returnAttachments[1].file instanceof Blob).to.be.true;
+        expect(returnAttachments[2].file instanceof Blob).to.be.true;
+      })
+      .then(done)
+      .catch(done);
+  });
+});

--- a/test/services/fhirServiceTest.ts
+++ b/test/services/fhirServiceTest.ts
@@ -13,9 +13,7 @@ import testVariables from '../testUtils/testVariables';
 import fhirValidator from '../../src/lib/fhirValidator';
 import stu3FhirResources from '../testUtils/stu3FhirResources';
 import recordService from '../../src/services/recordService';
-import { D4LSDK } from '../../src/d4l';
-import documentRoutes from '../../src/routes/documentRoutes';
-import DocumentReference, { DOCUMENT_REFERENCE } from '../../src/lib/models/fhir/DocumentReference';
+import DocumentReference from '../../src/lib/models/fhir/DocumentReference';
 import { FHIR_VERSION_STU3, FHIR_VERSION_R4 } from '../../src/lib/models/fhir/helper';
 import { setAttachmentsToResource } from '../../src/services/attachmentService';
 
@@ -296,7 +294,7 @@ describe('convertToExposedRecord', () => {
     expect(exposedRecord.id).to.equal(recordId);
     expect(exposedRecord.customCreationDate.getTime()).to.equal(customCreationDate.getTime());
     expect(exposedRecord.updatedDate.getTime()).to.equal(updatedDate.getTime());
-    for (const key in exposedRecord.fhirResource) {
+    for (const key of Object.keys(exposedRecord.fhirResource)) {
       if (key !== 'id') {
         expect(JSON.stringify(exposedRecord.fhirResource[key])).to.equal(
           JSON.stringify(stu3FhirResources.carePlan[key])
@@ -404,7 +402,7 @@ describe('fhirService', () => {
           const { args } = createRecordStub.getCall(0);
           expect(args[1].tags.toString()).to.contain('fhirversion=3%2e0%2e1');
           expect(createRecordStub).to.be.calledOnce;
-          for (const key in record.fhirResource) {
+          for (const key of Object.keys(record.fhirResource)) {
             if (key !== 'id') {
               expect(JSON.stringify(record.fhirResource[key])).to.equal(
                 JSON.stringify(res.fhirResource[key])
@@ -426,7 +424,7 @@ describe('fhirService', () => {
           const { args } = createRecordStub.getCall(0);
           expect(args[1].tags.toString()).to.contain('fhirversion=4%2e0%2e1');
           expect(createRecordStub).to.be.calledOnce;
-          for (const key in record.fhirResource) {
+          for (const key of Object.keys(record.fhirResource)) {
             if (key !== 'id') {
               expect(JSON.stringify(record.fhirResource[key])).to.equal(
                 JSON.stringify(res.fhirResource[key])
@@ -477,7 +475,7 @@ describe('fhirService', () => {
             attachmentKey: undefined,
             customCreationDate,
           });
-          for (const key in record.fhirResource) {
+          for (const key of Object.keys(record.fhirResource)) {
             if (key !== 'id') {
               expect(JSON.stringify(record.fhirResource[key])).to.equal(
                 JSON.stringify(res.fhirResource[key])
@@ -508,7 +506,7 @@ describe('fhirService', () => {
             attachmentKey: undefined,
             customCreationDate,
           });
-          for (const key in record.fhirResource) {
+          for (const key of Object.keys(record.fhirResource)) {
             if (key !== 'id') {
               expect(JSON.stringify(record.fhirResource[key])).to.equal(
                 JSON.stringify(res.fhirResource[key])
@@ -539,7 +537,7 @@ describe('fhirService', () => {
             attachmentKey: undefined,
             customCreationDate,
           });
-          for (const key in record.fhirResource) {
+          for (const key of Object.keys(record.fhirResource)) {
             if (key !== 'id') {
               expect(JSON.stringify(record.fhirResource[key])).to.equal(
                 JSON.stringify(res.fhirResource[key])

--- a/test/services/fhirServiceTest.ts
+++ b/test/services/fhirServiceTest.ts
@@ -294,13 +294,13 @@ describe('convertToExposedRecord', () => {
     expect(exposedRecord.id).to.equal(recordId);
     expect(exposedRecord.customCreationDate.getTime()).to.equal(customCreationDate.getTime());
     expect(exposedRecord.updatedDate.getTime()).to.equal(updatedDate.getTime());
-    for (const key of Object.keys(exposedRecord.fhirResource)) {
+    Object.keys(exposedRecord.fhirResource).forEach(key => {
       if (key !== 'id') {
         expect(JSON.stringify(exposedRecord.fhirResource[key])).to.equal(
           JSON.stringify(stu3FhirResources.carePlan[key])
         );
       }
-    }
+    });
     expect(exposedRecord.fhirResource.id).to.equal(recordId);
     expect(exposedRecord.partner).to.equal('1');
     expect(JSON.stringify(exposedRecord.annotations)).to.equal(JSON.stringify([]));
@@ -402,13 +402,13 @@ describe('fhirService', () => {
           const { args } = createRecordStub.getCall(0);
           expect(args[1].tags.toString()).to.contain('fhirversion=3%2e0%2e1');
           expect(createRecordStub).to.be.calledOnce;
-          for (const key of Object.keys(record.fhirResource)) {
+          Object.keys(record.fhirResource).forEach(key => {
             if (key !== 'id') {
               expect(JSON.stringify(record.fhirResource[key])).to.equal(
                 JSON.stringify(res.fhirResource[key])
               );
             }
-          }
+          });
           done();
         })
         .catch(done);
@@ -424,13 +424,13 @@ describe('fhirService', () => {
           const { args } = createRecordStub.getCall(0);
           expect(args[1].tags.toString()).to.contain('fhirversion=4%2e0%2e1');
           expect(createRecordStub).to.be.calledOnce;
-          for (const key of Object.keys(record.fhirResource)) {
+          Object.keys(record.fhirResource).forEach(key => {
             if (key !== 'id') {
               expect(JSON.stringify(record.fhirResource[key])).to.equal(
                 JSON.stringify(res.fhirResource[key])
               );
             }
-          }
+          });
           done();
         })
         .catch(done);
@@ -475,13 +475,13 @@ describe('fhirService', () => {
             attachmentKey: undefined,
             customCreationDate,
           });
-          for (const key of Object.keys(record.fhirResource)) {
+          Object.keys(record.fhirResource).forEach(key => {
             if (key !== 'id') {
               expect(JSON.stringify(record.fhirResource[key])).to.equal(
                 JSON.stringify(res.fhirResource[key])
               );
             }
-          }
+          });
           done();
         })
         .catch(done);
@@ -506,13 +506,13 @@ describe('fhirService', () => {
             attachmentKey: undefined,
             customCreationDate,
           });
-          for (const key of Object.keys(record.fhirResource)) {
+          Object.keys(record.fhirResource).forEach(key => {
             if (key !== 'id') {
               expect(JSON.stringify(record.fhirResource[key])).to.equal(
                 JSON.stringify(res.fhirResource[key])
               );
             }
-          }
+          });
           done();
         })
         .catch(done);
@@ -537,13 +537,13 @@ describe('fhirService', () => {
             attachmentKey: undefined,
             customCreationDate,
           });
-          for (const key of Object.keys(record.fhirResource)) {
+          Object.keys(record.fhirResource).forEach(key => {
             if (key !== 'id') {
               expect(JSON.stringify(record.fhirResource[key])).to.equal(
                 JSON.stringify(res.fhirResource[key])
               );
             }
-          }
+          });
           done();
         })
         .catch(done);

--- a/test/services/fhirServiceTest.ts
+++ b/test/services/fhirServiceTest.ts
@@ -6,11 +6,8 @@ import chai from 'chai';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import fhirService, {
-  attachBlobs,
+  convertToExposedRecord,
   prepareSearchParameters,
-  setAttachmentsToResource,
-  getCleanAttachmentsFromResource,
-  cleanResource,
 } from '../../src/services/fhirService';
 import testVariables from '../testUtils/testVariables';
 import fhirValidator from '../../src/lib/fhirValidator';
@@ -20,69 +17,11 @@ import { D4LSDK } from '../../src/d4l';
 import documentRoutes from '../../src/routes/documentRoutes';
 import DocumentReference, { DOCUMENT_REFERENCE } from '../../src/lib/models/fhir/DocumentReference';
 import { FHIR_VERSION_STU3, FHIR_VERSION_R4 } from '../../src/lib/models/fhir/helper';
+import { setAttachmentsToResource } from '../../src/services/attachmentService';
 
 chai.use(sinonChai);
 
 const { expect } = chai;
-
-describe('cleanResource', () => {
-  it('works on a mutable documentReference', () => {
-    const resource = {
-      resourceType: DOCUMENT_REFERENCE,
-      content: [
-        {
-          attachment: {
-            file: 'Pretend this is a file to be deleted',
-            anotherProperty: 'I should survive this operation',
-          },
-        },
-      ],
-    };
-    const cleanedResource = cleanResource(resource);
-    // @ts-ignore
-    expect(cleanedResource.content[0].attachment.file).to.be.undefined;
-    // @ts-ignore
-    expect(cleanedResource.content[0].attachment.anotherProperty).to.equal(
-      'I should survive this operation'
-    );
-    expect(resource.content[0].attachment.file).not.to.be.undefined;
-    expect(resource.content[0].attachment.anotherProperty).to.equal(
-      'I should survive this operation'
-    );
-  });
-
-  it('works on an immutable documentReference', () => {
-    const resource = {
-      resourceType: DOCUMENT_REFERENCE,
-    };
-
-    Object.defineProperty(resource, 'content', {
-      value: [
-        {
-          attachment: {
-            file: 'Pretend this is a file to be deleted',
-            anotherProperty: 'I should survive this operation',
-          },
-        },
-      ],
-      configurable: false,
-      writable: false,
-    });
-    const cleanedResource = cleanResource(resource);
-    // @ts-ignore
-    expect(cleanedResource.content[0].attachment.file).to.be.undefined;
-    // @ts-ignore
-    expect(cleanedResource.content[0].attachment.anotherProperty).to.equal(
-      'I should survive this operation'
-    );
-    // @ts-ignore
-    expect(resource.content[0].attachment.file).not.to.be.undefined;
-    // @ts-ignore
-    expect(resource.content[0].attachment.anotherProperty).to.equal(
-      'I should survive this operation'
-    );
-  });
-});
 
 describe('prepareSearchParameters', () => {
   it('correctly prepares simple parameters', () => {
@@ -334,422 +273,39 @@ describe('setAttachmentsToResource', () => {
   });
 });
 
-describe('getAttachmentsFromResource', () => {
-  it('should return the Attachments of a DocumentReference', () => {
-    const documentReference = {
-      resourceType: 'DocumentReference',
-      content: [{ attachment: { image: 'simpleImage' } }, { attachment: { document: 'pdf' } }],
-    };
-    const attachments = getCleanAttachmentsFromResource(documentReference);
-    expect(attachments).to.deep.equal([{ image: 'simpleImage' }, { document: 'pdf' }]);
-  });
+describe('convertToExposedRecord', () => {
+  const userId = 'user_id';
+  const recordId = 'record_id';
+  const customCreationDate = new Date('2017-09-19');
+  const updatedDate = new Date('2017-09-19T09:29:48.278');
 
-  it('should return an empty array when content is not set on DocumentReference', () => {
-    const documentReference = {};
-    const attachments = getCleanAttachmentsFromResource(documentReference);
-    expect(documentReference).to.deep.equal({});
-    expect(attachments).to.deep.equal([]);
-  });
+  const decryptedRecord = {
+    id: recordId,
+    customCreationDate,
+    user_id: userId,
+    fhirResource: stu3FhirResources.carePlan,
+    tags: ['tag1', 'tag2', testVariables.secondTag],
+    version: 1,
+    status: 'Active',
+    updatedDate,
+  };
 
-  it('should return the Attachments of a Patient', () => {
-    const patient = {
-      resourceType: 'Patient',
-      photo: [{ image: 'simpleImage' }, { document: 'pdf' }],
-    };
-    const attachments = getCleanAttachmentsFromResource(patient);
-    expect(attachments).to.deep.equal([{ image: 'simpleImage' }, { document: 'pdf' }]);
-  });
+  it('correctly converts a decrypted to an exposed record', () => {
+    const exposedRecord = convertToExposedRecord(decryptedRecord);
 
-  it('should return the Attachments of a Practitioner', () => {
-    const practitioner = {
-      resourceType: 'Practitioner',
-      photo: [{ image: 'simpleImage' }, { document: 'pdf' }],
-    };
-    const attachments = getCleanAttachmentsFromResource(practitioner);
-    expect(attachments).to.deep.equal([{ image: 'simpleImage' }, { document: 'pdf' }]);
-  });
-
-  it('should return the Attachments of a Medication', () => {
-    const medication = {
-      resourceType: 'Medication',
-      image: [{ image: 'simpleImage' }, { document: 'pdf' }],
-    };
-    const attachments = getCleanAttachmentsFromResource(medication);
-    expect(attachments).to.deep.equal([{ image: 'simpleImage' }, { document: 'pdf' }]);
-  });
-
-  it('should return the Attachments of a DiagnosticReport', () => {
-    const diagnosticReport = {
-      resourceType: 'DiagnosticReport',
-      presentedForm: [{ image: 'simpleImage' }, { document: 'pdf' }],
-    };
-    const attachments = getCleanAttachmentsFromResource(diagnosticReport);
-    expect(attachments).to.deep.equal([{ image: 'simpleImage' }, { document: 'pdf' }]);
-  });
-
-  it('should return the Attachments of an Observation with a component and a valueAttachment', () => {
-    const practitioner = {
-      resourceType: 'Observation',
-      valueAttachment: { image: 'simpleImage' },
-      component: [{ valueAttachment: { document: 'pdf' } }],
-    };
-    const attachments = getCleanAttachmentsFromResource(practitioner);
-    expect(attachments).to.deep.equal([{ image: 'simpleImage' }, { document: 'pdf' }]);
-  });
-
-  it('should return the Attachments of an Observation with only a component attachment', () => {
-    const practitioner = {
-      resourceType: 'Observation',
-      component: [
-        { valueAttachment: { image: 'simpleImage' } },
-        { valueString: 'i am string' },
-        { valueAttachment: { document: 'pdf' } },
-      ],
-    };
-    const attachments = getCleanAttachmentsFromResource(practitioner);
-    expect(attachments).to.deep.equal([{ image: 'simpleImage' }, { document: 'pdf' }]);
-  });
-
-  it('should return the Attachments of an Observation with only a valueAttachment', () => {
-    const practitioner = {
-      resourceType: 'Observation',
-      valueAttachment: { image: 'simpleImage' },
-    };
-    const attachments = getCleanAttachmentsFromResource(practitioner);
-    expect(attachments).to.deep.equal([{ image: 'simpleImage' }]);
-  });
-
-  it('should return no attachments of an Observation with no valueAttachment and no component-based attachments', () => {
-    const practitioner = {
-      resourceType: 'Observation',
-    };
-    const attachments = getCleanAttachmentsFromResource(practitioner);
-    expect(attachments).to.deep.equal([]);
-  });
-
-  it('should return the Attachments of a Questionnaire', () => {
-    const questionnaire = {
-      resourceType: 'Questionnaire',
-      item: [{ initialAttachment: { document: 'pdf' } }],
-    };
-    const attachments = getCleanAttachmentsFromResource(questionnaire);
-    expect(attachments).to.deep.equal([{ document: 'pdf' }]);
-  });
-
-  it('should not return the non-existent attachments of a Questionnaire', () => {
-    const questionnaire = {
-      resourceType: 'Questionnaire',
-      item: [{ initialString: 'i am a string' }],
-    };
-    const attachments = getCleanAttachmentsFromResource(questionnaire);
-    expect(attachments).to.deep.equal([]);
-  });
-
-  it('should return the Attachments of a QuestionnaireResponse', () => {
-    const questionnaire = {
-      resourceType: 'QuestionnaireResponse',
-      item: [
-        {
-          answer: [
-            { valueAttachment: { document: 'pdf' } },
-            { valueString: 'still just a string' },
-          ],
-        },
-        {
-          answer: [{ valueAttachment: { image: 'simpleImage' } }],
-        },
-      ],
-    };
-    const attachments = getCleanAttachmentsFromResource(questionnaire);
-    expect(attachments).to.deep.equal([{ document: 'pdf' }, { image: 'simpleImage' }]);
-  });
-
-  it('should return an empty array for QuestionnaireResponse with no valueAttachments', () => {
-    const questionnaire = {
-      resourceType: 'QuestionnaireResponse',
-      item: [
-        {
-          answer: [{ valueString: 'still just a string' }],
-        },
-      ],
-    };
-    const attachments = getCleanAttachmentsFromResource(questionnaire);
-    expect(attachments).to.deep.equal([]);
-  });
-});
-
-describe('attachBlobs', () => {
-  let uploadDocumentStub;
-  const mockPdfBlob = new Uint8Array([0x25, 0x50, 0x44, 0x46, 0x2d]);
-  const mockPngBlob = new Uint8Array([0x89, 0x50, 0x4e, 0x47]);
-
-  beforeEach(() => {
-    uploadDocumentStub = sinon
-      .stub(documentRoutes, 'uploadDocument')
-      .returns(Promise.resolve({ document_id: 'document_id' }));
-  });
-
-  afterEach(() => {
-    uploadDocumentStub.restore();
-  });
-
-  it('correctly attaches a single non-image', done => {
-    fetch('/fileSamples/sample.pdf')
-      .then(res => res.blob())
-      .then(resAsFile => {
-        const newAttachment = {
-          file: resAsFile, // not that the actual image matters, all based on props
-          title: 'not a doctor',
-        };
-
-        // technically not encrypted at this point
-        const encryptedFiles = [mockPdfBlob];
-        return attachBlobs({
-          encryptedFiles,
-          ownerId: testVariables.userId,
-          oldAttachments: [],
-          // @ts-ignore
-          newAttachments: [newAttachment],
-          // @ts-ignore
-          resource: new D4LSDK.models.DocumentReference(stu3FhirResources.documentReference),
-        });
-      })
-      .then(([resource, returnResource]) => {
-        // @ts-ignore
-        const uploadAttachments = resource.getAttachments();
-        // @ts-ignore
-        const returnAttachments = returnResource.getAttachments();
-        expect(uploadDocumentStub).to.be.calledOnce;
-        expect(uploadAttachments.length).to.equal(returnAttachments.length);
-        expect(uploadAttachments[0].file).to.be.undefined;
-        expect(returnAttachments[0].file).to.not.be.undefined;
-        expect(returnAttachments[0].file instanceof Blob).to.be.true;
-      })
-      .then(done)
-      .catch(done);
-  });
-
-  it('correctly attaches a single image with preview and thumbnail', done => {
-    fetch('/fileSamples/sample.png')
-      .then(res => res.blob())
-      .then(resAsFile => {
-        const newAttachment = {
-          file: resAsFile, // not that the actual image matters, all based on props
-          title: 'not a doctor',
-          isImage: true,
-          hasPreview: true,
-          hasThumb: true,
-        };
-
-        // technically not encrypted at this point
-        const encryptedFiles = [mockPngBlob, mockPngBlob, mockPngBlob];
-        return attachBlobs({
-          encryptedFiles,
-          ownerId: testVariables.userId,
-          oldAttachments: [],
-          newAttachments: [newAttachment],
-          // @ts-ignore
-          resource: new D4LSDK.models.DocumentReference(stu3FhirResources.documentReference),
-        });
-      })
-      .then(([resource, returnResource]) => {
-        // @ts-ignore
-        const uploadAttachments = resource.getAttachments();
-        // @ts-ignore
-        const returnAttachments = returnResource.getAttachments();
-        expect(uploadDocumentStub).to.be.calledThrice;
-        expect(uploadAttachments.length).to.equal(returnAttachments.length);
-        expect(uploadAttachments[0].file).to.be.undefined;
-        expect(returnAttachments[0].file).to.not.be.undefined;
-        // @ts-ignore
-        expect(returnResource.identifier).to.not.be.undefined;
-        expect(returnAttachments[0].file instanceof Blob).to.be.true;
-      })
-      .then(done)
-      .catch(done);
-  });
-
-  it('correctly attaches a single image with just a thumbnail', done => {
-    let attachment;
-    fetch('/fileSamples/sample.png')
-      .then(res => res.blob())
-      .then(resAsFile => {
-        attachment = {
-          file: resAsFile, // not that the actual image matters, all based on props
-          title: 'not a doctor',
-          isImage: true,
-          hasThumb: true,
-        };
-
-        // technically not encrypted at this point
-        const encryptedFiles = [mockPngBlob, mockPngBlob];
-        return attachBlobs({
-          encryptedFiles,
-          ownerId: testVariables.userId,
-          oldAttachments: [],
-          newAttachments: [attachment],
-          // @ts-ignore
-          resource: new D4LSDK.models.DocumentReference(stu3FhirResources.documentReference),
-        });
-      })
-      .then(([resource, returnResource]) => {
-        // @ts-ignore
-        const uploadAttachments = resource.getAttachments();
-        // @ts-ignore
-        const returnAttachments = returnResource.getAttachments();
-        expect(uploadDocumentStub).to.be.calledTwice;
-        expect(uploadAttachments.length).to.equal(returnAttachments.length);
-        expect(uploadAttachments[0].file).to.be.undefined;
-        expect(returnAttachments[0].file).to.not.be.undefined;
-        // @ts-ignore
-        expect(returnResource.identifier).to.not.be.undefined;
-        expect(returnAttachments[0].file instanceof Blob).to.be.true;
-      })
-      .then(done)
-      .catch(done);
-  });
-
-  it('correctly attaches a single image with no thumbnail or preview', done => {
-    let attachment;
-    fetch('/fileSamples/sample.png')
-      .then(res => res.blob())
-      .then(resAsFile => {
-        attachment = {
-          file: resAsFile, // not that the actual image matters, all based on props
-          title: 'not a doctor',
-          isImage: true,
-        };
-
-        // technically not encrypted at this point
-        const encryptedFiles = [mockPngBlob];
-        return attachBlobs({
-          encryptedFiles,
-          ownerId: testVariables.userId,
-          oldAttachments: [],
-          newAttachments: [attachment],
-          // @ts-ignore
-          resource: new D4LSDK.models.DocumentReference(stu3FhirResources.documentReference),
-        });
-      })
-      .then(([resource, returnResource]) => {
-        // @ts-ignore
-        const uploadAttachments = resource.getAttachments();
-        // @ts-ignore
-        const returnAttachments = returnResource.getAttachments();
-        expect(uploadDocumentStub).to.be.calledOnce;
-        expect(uploadAttachments.length).to.equal(returnAttachments.length);
-        expect(uploadAttachments[0].file).to.be.undefined;
-        expect(returnAttachments[0].file).to.not.be.undefined;
-        // @ts-ignore
-        expect(returnResource.identifier).to.not.be.undefined;
-        expect(returnAttachments[0].file instanceof Blob).to.be.true;
-      })
-      .then(done)
-      .catch(done);
-  });
-
-  it('adds a second attachment but keeps the old one intact', done => {
-    fetch('/fileSamples/sample.pdf')
-      .then(res => res.blob())
-      .then(resAsFile => {
-        const newAttachment = {
-          file: resAsFile, // not that the actual image matters, all based on props
-          title: 'not a doctor',
-        };
-        const oldAttachment = {
-          file: resAsFile, // not that the actual image matters, all based on props
-          title: 'old attachment',
-        };
-
-        // technically not encrypted at this point
-        const encryptedFiles = [mockPdfBlob];
-        // @ts-ignore
-        const resource = new D4LSDK.models.DocumentReference(stu3FhirResources.documentReference);
-        resource.setAttachments([oldAttachment]);
-
-        return attachBlobs({
-          resource,
-          encryptedFiles,
-          ownerId: testVariables.userId,
-          // @ts-ignore
-          oldAttachments: [oldAttachment],
-          // @ts-ignore
-          newAttachments: [newAttachment],
-        });
-      })
-      .then(([resource, returnResource]) => {
-        // @ts-ignore
-        const uploadAttachments = resource.getAttachments();
-        // @ts-ignore
-        const returnAttachments = returnResource.getAttachments();
-        expect(uploadDocumentStub).to.be.calledOnce;
-        expect(uploadAttachments.length).to.equal(returnAttachments.length);
-        expect(uploadAttachments.length).to.equal(2);
-        expect(uploadAttachments[0].file).to.be.undefined;
-        expect(returnAttachments[0].file).to.not.be.undefined;
-        // @ts-ignore
-        expect(returnResource.identifier).to.not.be.undefined;
-        expect(returnAttachments[0].file instanceof Blob).to.be.true;
-        expect(returnAttachments[1].file instanceof Blob).to.be.true;
-      })
-      .then(done)
-      .catch(done);
-  });
-
-  it('works as expected with a document with one existing attachment and new ones', done => {
-    fetch('/fileSamples/sample.pdf')
-      .then(res => res.blob())
-      .then(resAsFile => {
-        const newAttachment1 = {
-          file: resAsFile,
-          title: 'not a doctor',
-          isImage: true,
-          hasPreview: true,
-          hasThumb: true,
-        };
-        const newAttachment2 = {
-          file: resAsFile,
-          title: 'fermulon',
-        };
-        const oldAttachment = {
-          file: resAsFile,
-          title: 'old attachment',
-        };
-
-        // technically not encrypted at this point
-        const encryptedFiles = [mockPngBlob, mockPngBlob, mockPngBlob, mockPdfBlob];
-        // @ts-ignore
-        const resource = new D4LSDK.models.DocumentReference(stu3FhirResources.documentReference);
-        resource.setAttachments([oldAttachment]);
-
-        return attachBlobs({
-          resource,
-          encryptedFiles,
-          ownerId: testVariables.userId,
-          // @ts-ignore
-          oldAttachments: [oldAttachment],
-          // @ts-ignore
-          newAttachments: [newAttachment1, newAttachment2],
-        });
-      })
-      .then(([resource, returnResource]) => {
-        // @ts-ignore
-        const uploadAttachments = resource.getAttachments();
-        // @ts-ignore
-        const returnAttachments = returnResource.getAttachments();
-        expect(uploadDocumentStub.callCount).to.equal(4);
-        expect(uploadAttachments.length).to.equal(returnAttachments.length);
-        expect(uploadAttachments.length).to.equal(3);
-        expect(uploadAttachments[0].file).to.be.undefined;
-        expect(returnAttachments[0].file).to.not.be.undefined;
-        // @ts-ignore
-        expect(returnResource.identifier).to.not.be.undefined;
-        expect(returnAttachments[0].file instanceof Blob).to.be.true;
-        expect(returnAttachments[1].file instanceof Blob).to.be.true;
-        expect(returnAttachments[2].file instanceof Blob).to.be.true;
-      })
-      .then(done)
-      .catch(done);
+    expect(exposedRecord.id).to.equal(recordId);
+    expect(exposedRecord.customCreationDate.getTime()).to.equal(customCreationDate.getTime());
+    expect(exposedRecord.updatedDate.getTime()).to.equal(updatedDate.getTime());
+    for (const key in exposedRecord.fhirResource) {
+      if (key !== 'id') {
+        expect(JSON.stringify(exposedRecord.fhirResource[key])).to.equal(
+          JSON.stringify(stu3FhirResources.carePlan[key])
+        );
+      }
+    }
+    expect(exposedRecord.fhirResource.id).to.equal(recordId);
+    expect(exposedRecord.partner).to.equal('1');
+    expect(JSON.stringify(exposedRecord.annotations)).to.equal(JSON.stringify([]));
   });
 });
 
@@ -848,7 +404,13 @@ describe('fhirService', () => {
           const { args } = createRecordStub.getCall(0);
           expect(args[1].tags.toString()).to.contain('fhirversion=3%2e0%2e1');
           expect(createRecordStub).to.be.calledOnce;
-          expect(res).to.deep.equal(record);
+          for (const key in record.fhirResource) {
+            if (key !== 'id') {
+              expect(JSON.stringify(record.fhirResource[key])).to.equal(
+                JSON.stringify(res.fhirResource[key])
+              );
+            }
+          }
           done();
         })
         .catch(done);
@@ -864,7 +426,13 @@ describe('fhirService', () => {
           const { args } = createRecordStub.getCall(0);
           expect(args[1].tags.toString()).to.contain('fhirversion=4%2e0%2e1');
           expect(createRecordStub).to.be.calledOnce;
-          expect(res).to.deep.equal(record);
+          for (const key in record.fhirResource) {
+            if (key !== 'id') {
+              expect(JSON.stringify(record.fhirResource[key])).to.equal(
+                JSON.stringify(res.fhirResource[key])
+              );
+            }
+          }
           done();
         })
         .catch(done);
@@ -909,7 +477,13 @@ describe('fhirService', () => {
             attachmentKey: undefined,
             customCreationDate,
           });
-          expect(res).to.deep.equal(record);
+          for (const key in record.fhirResource) {
+            if (key !== 'id') {
+              expect(JSON.stringify(record.fhirResource[key])).to.equal(
+                JSON.stringify(res.fhirResource[key])
+              );
+            }
+          }
           done();
         })
         .catch(done);
@@ -934,7 +508,13 @@ describe('fhirService', () => {
             attachmentKey: undefined,
             customCreationDate,
           });
-          expect(res).to.deep.equal(record);
+          for (const key in record.fhirResource) {
+            if (key !== 'id') {
+              expect(JSON.stringify(record.fhirResource[key])).to.equal(
+                JSON.stringify(res.fhirResource[key])
+              );
+            }
+          }
           done();
         })
         .catch(done);
@@ -959,7 +539,13 @@ describe('fhirService', () => {
             attachmentKey: undefined,
             customCreationDate,
           });
-          expect(res).to.deep.equal(record);
+          for (const key in record.fhirResource) {
+            if (key !== 'id') {
+              expect(JSON.stringify(record.fhirResource[key])).to.equal(
+                JSON.stringify(res.fhirResource[key])
+              );
+            }
+          }
           done();
         })
         .catch(done);

--- a/test/services/recordServiceTest.ts
+++ b/test/services/recordServiceTest.ts
@@ -431,6 +431,79 @@ describe('services/recordService', () => {
     });
   });
 
+  describe('normalizeFallbackSearchResults', () => {
+    const conversionFunction = sinon.stub().returnsArg(0);
+    const firstResponse = {
+      records: [
+        {
+          id: 1,
+          content: 'content1',
+        },
+        {
+          id: 2,
+          content: 'content2',
+        },
+      ],
+      totalCount: 2,
+    };
+    const secondResponse = {
+      records: [
+        {
+          id: 3,
+          content: 'content3',
+        },
+        {
+          id: 4,
+          content: 'content4',
+        },
+      ],
+      totalCount: 2,
+    };
+    const thirdResponse = {
+      records: [
+        {
+          id: 3,
+          content: 'content3',
+        },
+        {
+          id: 5,
+          content: 'content5',
+        },
+      ],
+      totalCount: 2,
+    };
+
+    it('passes through a normal searchResultArray with just one response item', () => {
+      const normalizationResult = recordService.normalizeFallbackSearchResults({
+        responseArray: [firstResponse],
+        conversionFunction,
+      });
+      expect(normalizationResult.totalCount).to.equal(2);
+      expect(JSON.stringify(normalizationResult)).to.equal(JSON.stringify(firstResponse));
+    });
+
+    it('merges a searchResultArray with multiple responses (but no duplicates)', () => {
+      const normalizationResult = recordService.normalizeFallbackSearchResults({
+        responseArray: [firstResponse, secondResponse],
+        conversionFunction,
+      });
+      expect(normalizationResult.totalCount).to.equal(4);
+      expect(JSON.stringify(normalizationResult)).to.equal(
+        '{"records":[{"id":1,"content":"content1"},{"id":2,"content":"content2"},{"id":3,"content":"content3"},{"id":4,"content":"content4"}],"totalCount":4}'
+      );
+    });
+    it('merges a searchResultArray with multiple responses and removes duplicates', () => {
+      const normalizationResult = recordService.normalizeFallbackSearchResults({
+        responseArray: [firstResponse, secondResponse, thirdResponse],
+        conversionFunction,
+      });
+      expect(normalizationResult.totalCount).to.equal(5);
+      expect(JSON.stringify(normalizationResult)).to.equal(
+        '{"records":[{"id":1,"content":"content1"},{"id":2,"content":"content2"},{"id":3,"content":"content3"},{"id":4,"content":"content4"},{"id":5,"content":"content5"}],"totalCount":5}'
+      );
+    });
+  });
+
   describe('deleteRecord', () => {
     it('should resolve, when called with userId and recordId', done => {
       recordService


### PR DESCRIPTION
### Summary of the issue

This brings back the original pull request https://github.com/gesundheitscloud/hc-sdk-js/pull/375
As written back then:
This fixes an issue where documents created on the native apps where an attachment was deleted would not reload in the apps because the type was set to an empty string whereas it should be an empty object.

https://gesundheitscloud.atlassian.net/browse/SDK-453

### Due diligence checklist
- [x] Updated version in package.json if applicable.
- [x] Added/updated tests.
- [ ] Add documentation
- [ ] If this change affects SDK consumers: communicate changes.


### TODOs
- [ ] Mention any outstanding issues or tasks you need to perform after the merge.
