### PR TITLE
✨ SDK-613 HUB-1772 Fetch deleted records

### DIFF
--- a/docs/sdk.md
+++ b/docs/sdk.md
@@ -579,8 +579,9 @@ Lets you specify options for the `fetchResource` method.
 | resourceType | String | (optional) Type of requested FHIR resources |
 | fhirVersion | String | (optional) The FHIR verion of the resources, for example "4.0.1" |
 | partner | String | (optional) ID of the partner the records where uploaded from |
-| annotations | String[] | (optional) Custom annotations to filter by
-| exclude_tags | String[] | (optional) Don't fetch resources with given tags
+| annotations | String[] | (optional) Custom annotations to filter by |
+| exclude_tags | String[] | (optional) Don't fetch resources with given tags |
+| include_deleted | Boolean | (optional) Fetch deleted records |
 
 #### Resolves
 | Property | Type | Description |
@@ -633,6 +634,7 @@ To count the FHIR resources you uploaded, use the `countResources` method.
 |------|:-----|:------------|
 | start_date | Date |(optional) Earliest date for which to return records |
 | end_date | Date | (optional) Latest date for which to return records |
+| include_deleted | Boolean | (optional) include deleted records |
 
 #### Resolves
 | Property | Type | Description |

--- a/docs/sdk.md
+++ b/docs/sdk.md
@@ -321,7 +321,7 @@ is <https://www.hl7.org/fhir/careplan-example.json.html>.
     },
     annotations: ["blood test report", "dr john doe"],
     customCreationDate: "2018-05-07T10:09:09.394Z",
-    updatedDate: "2018-05-07",
+    updatedDate: "2018-05-07T10:09:09.394Z",
     partner: "partner_id" // Partner ID from that the record is uploaded. Refers to the apps using the SDK.
 }
 ```
@@ -368,7 +368,7 @@ D4L.SDK.updateResource(ownerId, fhirResource, ["blood test report", "dr john mil
     },
     annotations: ["blood test report", "dr john miller"],
     customCreationDate: "2018-05-07T10:09:09.394Z",
-    updatedDate: "2018-05-07",
+    updatedDate: "2018-05-07T10:09:09.394Z",
     partner: "partner_id" // Partner ID from which the record is uploaded. Refers to the apps using the SDK.
 
 }
@@ -408,7 +408,7 @@ D4L.SDK.fetchResource('1cf5ee52-88dc-406a-bf7b-bc5e26a17b47', '500b2aa5-2728-48f
     },
     annotations: ["blood test report", "dr john doe"],
     customCreationDate: "2018-05-07T10:09:09.394Z",
-    updatedDate: "2018-05-07",
+    updatedDate: "2018-05-07T10:09:09.394Z",
     partner: "partner_id"
 }
 ```
@@ -576,6 +576,8 @@ Lets you specify options for the `fetchResource` method.
 | offset | String | (optional, default: 0) Number of records to skip when retrieving |
 | start_date | Date |(optional) Earliest date for which to return records |
 | end_date | Date | (optional) Latest date for which to return records |
+| start_updated_date | Datetime |(optional) Earliest date for which to return records based on last modification |
+| end_updated_date | Datetime | (optional) Latest date for which to return records based on last modification |
 | resourceType | String | (optional) Type of requested FHIR resources |
 | fhirVersion | String | (optional) The FHIR verion of the resources, for example "4.0.1" |
 | partner | String | (optional) ID of the partner the records where uploaded from |
@@ -613,7 +615,7 @@ D4L.SDK.fetchResources('1cf5ee52-88dc-406a-bf7b-bc5e26a17b47', {
         },
         annotations: ["blood test report", "dr john doe"],
         customCreationDate: "2018-05-07T10:09:09.394Z",
-        updatedDate: "2018-05-07",
+        updatedDate: "2018-05-07T10:09:09.394Z",
         partner: "partner_id"
     }
 ]
@@ -634,6 +636,8 @@ To count the FHIR resources you uploaded, use the `countResources` method.
 |------|:-----|:------------|
 | start_date | Date |(optional) Earliest date for which to return records |
 | end_date | Date | (optional) Latest date for which to return records |
+| start_updated_date | Datetime |(optional) Earliest date for which to return records based on last modification |
+| end_updated_date | Datetime | (optional) Latest date for which to return records based on last modification |
 | include_deleted | Boolean | (optional) include deleted records |
 
 #### Resolves

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@d4l/js-sdk",
-  "version": "5.7.0",
+  "version": "5.8.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@d4l/js-sdk",
-  "version": "5.7.0",
+  "version": "5.8.0",
   "D4L": {
     "data_model_version": 1
   },

--- a/src/services/fhirService.ts
+++ b/src/services/fhirService.ts
@@ -51,6 +51,7 @@ const SUPPORTED_PARAMS = [
   'include_deleted',
 ];
 
+/* eslint-disable complexity */
 export const prepareSearchParameters = (params: Params): SearchParameters => {
   if (!Object.keys(params).every(key => includes(SUPPORTED_PARAMS, key))) {
     throw new Error(

--- a/src/services/fhirService.ts
+++ b/src/services/fhirService.ts
@@ -39,6 +39,8 @@ const SUPPORTED_PARAMS = [
   'offset',
   'start_date',
   'end_date',
+  'start_updated_date',
+  'end_updated_date',
   'fhirVersion',
   'tags',
   'exclude_tags',
@@ -61,6 +63,9 @@ export const prepareSearchParameters = (params: Params): SearchParameters => {
     ...(params.offset && { offset: params.offset }),
     ...(params.start_date && { start_date: params.start_date }),
     ...(params.end_date && { end_date: params.end_date }),
+    ...(params.start_updated_date && { start_updated_date: params.start_updated_date }),
+    ...(params.end_updated_date && { end_updated_date: params.end_updated_date }),
+    ...(params.include_deleted && { include_deleted: params.include_deleted }),
   };
 
   if (params.resourceType) {

--- a/src/services/fhirService.ts
+++ b/src/services/fhirService.ts
@@ -23,9 +23,6 @@ import { isAllowedByteSequence } from '../lib/fileValidator';
 import Attachment from '../lib/models/fhir/Attachment';
 import taggingUtils, { tagKeys } from '../lib/taggingUtils';
 import documentRoutes from '../routes/documentRoutes';
-import createCryptoService from './createCryptoService';
-import recordService from './recordService';
-import { DecryptedFhirRecord, FetchResponse, Params, Record, SearchParameters } from './types';
 import {
   addPreviewsToAttachments,
   attachBlobs,
@@ -33,6 +30,9 @@ import {
   getCleanAttachmentsFromResource,
   setAttachmentsToResource,
 } from './attachmentService';
+import createCryptoService from './createCryptoService';
+import recordService from './recordService';
+import { DecryptedFhirRecord, FetchResponse, Params, Record, SearchParameters } from './types';
 
 const SUPPORTED_PARAMS = [
   'limit',
@@ -46,6 +46,7 @@ const SUPPORTED_PARAMS = [
   'annotations',
   'resourceType',
   'partner',
+  'include_deleted',
 ];
 
 export const prepareSearchParameters = (params: Params): SearchParameters => {
@@ -100,6 +101,7 @@ export const convertToExposedRecord = (decryptedRecord: DecryptedFhirRecord) => 
     id: clonedRecord.id,
     partner: taggingUtils.getTagValueFromList(clonedRecord.tags, tagKeys.partner),
     updatedDate: clonedRecord.updatedDate,
+    status: clonedRecord.status,
   };
   exposedRecord.fhirResource.id = clonedRecord.id;
   return exposedRecord;

--- a/src/services/recordService.ts
+++ b/src/services/recordService.ts
@@ -265,6 +265,7 @@ const recordService = {
         id: record.record_id,
         tags: decryptedTags,
         updatedDate: new Date(record.createdAt),
+        status: record.status,
       };
 
       if (decryptedTags?.some(tag => tag === taggingUtils.generateAppDataFlagTag())) {

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -11,6 +11,7 @@ export interface Params {
   annotations?: string[];
   resourceType?: string;
   partner?: string;
+  include_deleted?: boolean;
 }
 
 export type SearchParameters = {
@@ -59,6 +60,7 @@ export interface DecryptedFhirRecord {
   customCreationDate?: Date;
   updatedDate?: Date;
   commonKeyId?: string;
+  status?: string;
 }
 
 /** The record we expose to users should not expose any sensitive information.
@@ -74,6 +76,7 @@ export interface Record {
   customCreationDate?: Date;
   updatedDate?: Date;
   partner?: string;
+  status?: string;
 }
 
 /** AppData */

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -5,6 +5,8 @@ export interface Params {
   fhirVersion?: string;
   start_date?: string;
   end_date?: string;
+  start_updated_date?: string;
+  end_updated_date?: string;
   tags?: string[];
   exclude_tags?: string[];
   exclude_flags?: string[];
@@ -19,8 +21,11 @@ export type SearchParameters = {
   offset?: number;
   start_date?: string;
   end_date?: string;
+  start_updated_date?: string;
+  end_updated_date?: string;
   tags?: (Tag | TagGroup)[];
   exclude_tags?: (Tag | TagGroup)[];
+  include_deleted?: boolean;
 };
 
 export interface QueryParams {
@@ -28,8 +33,11 @@ export interface QueryParams {
   offset?: number;
   start_date?: string;
   end_date?: string;
+  start_updated_date?: string;
+  end_updated_date?: string;
   tags?: string[];
   exclude_tags?: string[];
+  include_deleted?: boolean;
 }
 
 export type Tag = string;

--- a/test/services/recordServiceTest.ts
+++ b/test/services/recordServiceTest.ts
@@ -380,7 +380,10 @@ describe('services/recordService', () => {
         offset: 20,
         start_date: '2017-06-06',
         end_date: '2017-08-08',
+        start_updated_date: '2017-06-06T00:00:00.00Z',
+        end_updated_date: '2017-08-08T00:00:00.00Z',
         exclude_tags: [testVariables.appDataFlag],
+        include_deleted: true,
         tags: [testVariables.tag, testVariables.secondTag],
       };
 
@@ -389,6 +392,9 @@ describe('services/recordService', () => {
         offset: 20,
         start_date: '2017-06-06',
         end_date: '2017-08-08',
+        start_updated_date: '2017-06-06T00:00:00.00Z',
+        end_updated_date: '2017-08-08T00:00:00.00Z',
+        include_deleted: true,
         exclude_tags: [testVariables.encryptedAppDataFlag],
         tags: [testVariables.encryptedTag, testVariables.encryptedSecondTag],
       };


### PR DESCRIPTION
### Summary of the issue

https://gesundheitscloud.atlassian.net/browse/SDK-613

Implement use of the Record services `include_deleted`, `start_updated_date` and  `end_updated_date` query parameter.
Export the records `Status` field to enable differentiation between active and deleted records.

Notes:
- There appeared to be lots of unused imports in `fhirService.ts` so I allowed my editor to clean that up.

### How to reproduce your bugfix or feature

Use `fetchResources` with the new parameter and see that deleted records are returned.


### Due diligence checklist
- [x] Updated version in package.json if applicable.
- [x] Added/updated tests.
- [x] Add documentation
- [ ] If this change affects SDK consumers: communicate changes.


### TODOs
- [ ] Mention any outstanding issues or tasks you need to perform after the merge.
