### PR TITLE
🐛 Fix updatedDate being timezoneless

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@d4l/js-sdk",
-  "version": "5.8.0",
+  "version": "5.8.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@d4l/js-sdk",
-  "version": "5.8.0",
+  "version": "5.8.1",
   "D4L": {
     "data_model_version": 1
   },

--- a/src/services/recordService.ts
+++ b/src/services/recordService.ts
@@ -146,7 +146,7 @@ const recordService = {
       id: result.record_id,
       tags: record.tags,
       // @ts-ignore
-      updatedDate: result.createdAt,
+      updatedDate: result.updated,
     };
 
     if ((record as DecryptedAppData).data) {
@@ -264,7 +264,7 @@ const recordService = {
         customCreationDate: new Date(record.date),
         id: record.record_id,
         tags: decryptedTags,
-        updatedDate: new Date(record.createdAt),
+        updatedDate: new Date(record.updated),
         status: record.status,
       };
 


### PR DESCRIPTION
### Summary of the issue
Describe what you did in this pull request. If applicable, link to an issue here, such as 
https://gesundheitscloud.atlassian.net/browse/SDK-

- the records `updatedDate` was derived from the `createdAt` time of the record, which does not have the `Z` for the timezone at the end. Thus the frontend treated it as local time. But it is actually in UTC, as it is the same date as `updated`, but `updated` did have the timezone

![image](https://user-images.githubusercontent.com/5717370/121319864-ea24c180-c90c-11eb-86c0-cdd30440314b.png)

### How to reproduce your bugfix or feature
Describe how to inspect and verify your changes.

- When you fetch all records via updatedDate and then take the most recent date to filter the next search you will never run out of records, since the updatedDate is 2 hours off due to timezone stuff (UTC vs +2)

### Due diligence checklist
- [x] Updated version in package.json if applicable.
- [ ] Added/updated tests.
- [ ] Add documentation
- [ ] If this change affects SDK consumers: communicate changes.


### TODOs
- [ ] Mention any outstanding issues or tasks you need to perform after the merge.
