### PR TITLE
[SDK-634] Fix retrieval of old iOS apps documents

### DIFF
--- a/src/lib/stringUtils.ts
+++ b/src/lib/stringUtils.ts
@@ -5,10 +5,21 @@ const stringUtils = {
       .toLowerCase();
   },
 
-  addFallbackPercentEncoding(string: string): string {
+  addFallbackJSEncoding(string: string): string {
     return encodeURIComponent(string).replace(
       /[!'()*\-_.~]/g,
       c => `%${c.charCodeAt(0).toString(16)}`
+    );
+  },
+
+  addFallbackIOSEncoding(string: string): string {
+    return encodeURIComponent(string.toLowerCase()).replace(
+      /[!'()*\-_.~]/g,
+      c =>
+        `%${c
+          .charCodeAt(0)
+          .toString(16)
+          .toUpperCase()}`
     );
   },
 
@@ -16,10 +27,20 @@ const stringUtils = {
     return decodeURIComponent(string);
   },
 
-  prepareForUpload(string: string, useFallback: boolean): string {
-    return useFallback
-      ? this.addFallbackPercentEncoding(string.toLowerCase().trim())
-      : this.addPercentEncoding(string.toLowerCase().trim());
+  prepareForUpload(
+    string: string,
+    useFallback: {
+      js?: boolean;
+      ios?: boolean;
+    } = { js: false, ios: false }
+  ): string {
+    if (useFallback.js) {
+      return this.addFallbackJSEncoding(string.toLowerCase().trim());
+    }
+    if (useFallback.ios) {
+      return this.addFallbackIOSEncoding(string.trim());
+    }
+    return this.addPercentEncoding(string.toLowerCase().trim());
   },
 };
 

--- a/test/lib/taggingUtilsTest.ts
+++ b/test/lib/taggingUtilsTest.ts
@@ -90,15 +90,28 @@ describe('taggingUtils', () => {
         '%3b%2c%2f%3f%3a%40%26%3d%2b%24%23%2d%5f%2e%21%7e%2a%27%28%29abc%20abc%20123'
     );
   });
-  it('verifies that buildTag returns correctly encoded tag (fallback mode)', () => {
+
+  it('verifies that buildTag returns correctly encoded tag (JS fallback mode)', () => {
     const tag = taggingUtils.buildTag(
       ";,/?:@&=+$#-_.!~*'()ABC abc 123",
       ";,/?:@&=+$#-_.!~*'()ABC abc 123",
-      true
+      { js: true }
     );
     expect(tag).to.equal(
       '%3B%2C%2F%3F%3A%40%26%3D%2B%24%23%2d%5f%2e%21%7e%2a%27%28%29abc%20abc%20123=' +
         '%3B%2C%2F%3F%3A%40%26%3D%2B%24%23%2d%5f%2e%21%7e%2a%27%28%29abc%20abc%20123'
+    );
+  });
+
+  it('verifies that buildTag returns correctly encoded tag (IOS fallback mode)', () => {
+    const tag = taggingUtils.buildTag(
+      ";,/?:@&=+$#-_.!~*'()ABC abc 123",
+      ";,/?:@&=+$#-_.!~*'()ABC abc 123",
+      { ios: true }
+    );
+    expect(tag).to.equal(
+      '%3B%2C%2F%3F%3A%40%26%3D%2B%24%23%2D%5F%2E%21%7E%2A%27%28%29abc%20abc%20123=' +
+        '%3B%2C%2F%3F%3A%40%26%3D%2B%24%23%2D%5F%2E%21%7E%2A%27%28%29abc%20abc%20123'
     );
   });
 
@@ -120,17 +133,17 @@ describe('taggingUtils', () => {
   });
 
   describe('getValue', () => {
-    it('returns correct tag-value when  is called with tag', () => {
+    it('returns correct tag-value when is called with tag', () => {
       const tagValue = taggingUtils.getValue(testVariables.secondTag);
       expect(tagValue).to.equal('1');
     });
 
-    it('returns correct tag-value when  is called with encoded tag', () => {
+    it('returns correct tag-value when is called with encoded tag', () => {
       const tagValue = taggingUtils.getValue(testVariables.encodedTag);
       expect(tagValue).to.equal('ann_otation');
     });
 
-    it('returns undefined whencalled with incorrect tag format', () => {
+    it('returns undefined when called with incorrect tag format', () => {
       const tagValue = taggingUtils.getValue('client%2');
       expect(tagValue).to.equal(undefined);
     });

--- a/test/services/fhirServiceTest.ts
+++ b/test/services/fhirServiceTest.ts
@@ -116,9 +116,14 @@ describe('prepareSearchParameters', () => {
     const preparedParams = prepareSearchParameters({
       fhirVersion: '3.0.1',
     });
-    expect(preparedParams).to.deep.equal({
-      tags: [['fhirversion=3%2e0%2e1', 'fhirversion=3.0.1']],
-    });
+
+    expect(preparedParams.tags.length).to.equal(1);
+    expect(preparedParams.tags[0].length).to.equal(3);
+    expect(preparedParams.tags[0]).to.deep.equal([
+      'fhirversion=3%2e0%2e1',
+      'fhirversion=3.0.1',
+      'fhirversion=3%2E0%2E1',
+    ]);
   });
 
   it('correctly prepares parameters including a fhir version 4.0.1', () => {
@@ -126,7 +131,7 @@ describe('prepareSearchParameters', () => {
       fhirVersion: '4.0.1',
     });
     expect(preparedParams).to.deep.equal({
-      tags: [['fhirversion=4%2e0%2e1', 'fhirversion=4.0.1']],
+      tags: [['fhirversion=4%2e0%2e1', 'fhirversion=4.0.1', 'fhirversion=4%2E0%2E1']],
     });
   });
 
@@ -135,7 +140,7 @@ describe('prepareSearchParameters', () => {
       annotations: ['***it was: agatha all along***'],
     });
     expect(preparedParams.tags.length).to.equal(1);
-    expect(preparedParams.tags[0].length).to.equal(3);
+    expect(preparedParams.tags[0].length).to.equal(4);
 
     expect(preparedParams).to.deep.equal({
       tags: [
@@ -143,6 +148,7 @@ describe('prepareSearchParameters', () => {
           'custom=%2a%2a%2ait%20was%3a%20agatha%20all%20along%2a%2a%2a', // Original
           'custom=%2a%2a%2ait%20was%3A%20agatha%20all%20along%2a%2a%2a', // JS SDK Bug
           'custom=***it was: agatha all along***', // KMP SDK Bug
+          'custom=%2A%2A%2Ait%20was%3A%20agatha%20all%20along%2A%2A%2A', // IOS SDK Bug
         ],
       ],
     });
@@ -156,7 +162,7 @@ describe('prepareSearchParameters', () => {
     expect(preparedParams.tags.length).to.equal(2);
     expect(typeof preparedParams.tags[0]).to.equal('string');
     expect(Array.isArray(preparedParams.tags[1])).to.equal(true);
-    expect(preparedParams.tags[1].length).to.equal(3);
+    expect(preparedParams.tags[1].length).to.equal(4);
 
     expect(preparedParams).to.deep.equal({
       tags: [
@@ -165,6 +171,7 @@ describe('prepareSearchParameters', () => {
           'custom=%2a%2a%2ait%20was%3a%20agatha%20all%20along%2a%2a%2a',
           'custom=%2a%2a%2ait%20was%3A%20agatha%20all%20along%2a%2a%2a',
           'custom=***it was: agatha all along***',
+          'custom=%2A%2A%2Ait%20was%3A%20agatha%20all%20along%2A%2A%2A',
         ],
       ],
     });
@@ -181,6 +188,7 @@ describe('prepareSearchParameters', () => {
           'custom=%2a%2a%2ait%20was%3a%20agatha%20all%20along%2a%2a%2a',
           'custom=%2a%2a%2ait%20was%3A%20agatha%20all%20along%2a%2a%2a',
           'custom=***it was: agatha all along***',
+          'custom=%2A%2A%2Ait%20was%3A%20agatha%20all%20along%2A%2A%2A',
         ],
       ],
       exclude_tags: [
@@ -188,6 +196,7 @@ describe('prepareSearchParameters', () => {
           'custom=%2a%2a%2ait%20was%3a%20agatha%20all%20along%2a%2a%2a',
           'custom=%2a%2a%2ait%20was%3A%20agatha%20all%20along%2a%2a%2a',
           'custom=***it was: agatha all along***',
+          'custom=%2A%2A%2Ait%20was%3A%20agatha%20all%20along%2A%2A%2A',
         ],
       ],
     });
@@ -698,6 +707,7 @@ describe('fhirService', () => {
                 'custom=%2a%2a%2ait%20was%3a%20agatha%20all%20along%2a%2a%2a',
                 'custom=%2a%2a%2ait%20was%3A%20agatha%20all%20along%2a%2a%2a',
                 'custom=***it was: agatha all along***',
+                'custom=%2A%2A%2Ait%20was%3A%20agatha%20all%20along%2A%2A%2A',
               ],
             ],
             exclude_tags: [testVariables.appDataFlag],


### PR DESCRIPTION
### Summary of the issue

Old iOS apps were tagging without lowercasing the percent encoding, so it's another case to add to the tags parameter when searching/counting.

https://gesundheitscloud.atlassian.net/browse/SDK-634

### Due diligence checklist
- [ ] Updated version in package.json if applicable.
- [x] Added/updated tests.
- [ ] Add documentation
- [ ] If this change affects SDK consumers: communicate changes.


### TODOs
- [ ] Updated version in package.json and release a new version
