### PR TITLE
✨ Support AND and OR for querying resources

### DIFF
--- a/docs/sdk.md
+++ b/docs/sdk.md
@@ -581,8 +581,8 @@ Lets you specify options for the `fetchResource` method.
 | resourceType | String | (optional) Type of requested FHIR resources |
 | fhirVersion | String | (optional) The FHIR verion of the resources, for example "4.0.1" |
 | partner | String | (optional) ID of the partner the records where uploaded from |
-| annotations | String[] | (optional) Custom annotations to filter by |
-| exclude_tags | String[] | (optional) Don't fetch resources with given tags |
+| annotations | (String or String[])[] | (optional) Custom annotations to filter by. Values in an array are combined to <or> |
+| exclude_tags | (String or String[])[] | (optional) Don't fetch resources with given tags. Values in an array are combined to <or> |
 | include_deleted | Boolean | (optional) Fetch deleted records |
 
 #### Resolves

--- a/docs/sdk.md
+++ b/docs/sdk.md
@@ -582,7 +582,7 @@ Lets you specify options for the `fetchResource` method.
 | fhirVersion | String | (optional) The FHIR verion of the resources, for example "4.0.1" |
 | partner | String | (optional) ID of the partner the records where uploaded from |
 | annotations | (String or String[])[] | (optional) Custom annotations to filter by. Values in an array are combined to <or> |
-| exclude_tags | (String or String[])[] | (optional) Don't fetch resources with given tags. Values in an array are combined to <or> |
+| exclude_tags | (String or String[])[] | (optional) Don't fetch resources with given tags. Values in an array are combined to <and> |
 | include_deleted | Boolean | (optional) Fetch deleted records |
 
 #### Resolves

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@d4l/js-sdk",
-  "version": "5.9.1",
+  "version": "5.10.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@d4l/js-sdk",
-      "version": "5.9.1",
+      "version": "5.10.0",
       "hasInstallScript": true,
       "license": "See license in LICENSE",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@d4l/js-sdk",
-  "version": "5.9.1",
+  "version": "5.10.0",
   "D4L": {
     "data_model_version": 1
   },

--- a/src/lib/taggingUtils.ts
+++ b/src/lib/taggingUtils.ts
@@ -114,23 +114,17 @@ const taggingUtils = {
    */
   generateFallbacksForSearch(label: string, value: string | string[]): Tag | TagGroup {
     const generateAllTags = (tagLabel: string, tagValue: string): TagGroup | Tag => {
-      /*
-      Original JS SDK implementation was inconsistent in lowercasing/uppercasing
-      some escaped characters
-    */
+      // Original JS SDK implementation was inconsistent in lower-/uppercasing
+      // some escaped characters
       const original: Tag = this.buildTag(tagLabel, tagValue);
       const fallbackJS: Tag = this.buildTag(tagLabel, tagValue, {
         js: true,
       });
 
-      /*
-      For a brief time the KMP SDK did not encode values and tags
-    */
+      //  For a brief time the KMP SDK did not encode values and tags
       const fallbackKMP: Tag = this.buildFallbackTag(tagLabel, tagValue);
 
-      /*
-      Old iOS apps were tagging without lowercasing the percent encoding
-    */
+      // Old iOS apps were tagging without lowercasing the percent encoding
       const fallbackIOS: Tag = this.buildTag(tagLabel, tagValue, {
         ios: true,
       });

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -8,9 +8,9 @@ export interface Params {
   start_updated_date?: string;
   end_updated_date?: string;
   tags?: string[];
-  exclude_tags?: string[];
+  exclude_tags?: (string | string[])[];
   exclude_flags?: string[];
-  annotations?: string[];
+  annotations?: (string | string[])[];
   resourceType?: string;
   partner?: string;
   include_deleted?: boolean;

--- a/test/services/fhirServiceTest.ts
+++ b/test/services/fhirServiceTest.ts
@@ -202,6 +202,67 @@ describe('prepareSearchParameters', () => {
     });
   });
 
+  it('correctly prepares search parameters with an <or> annotation', () => {
+    const preparedParams = prepareSearchParameters({
+      annotations: [['annotation1', 'annotation2']],
+    });
+    expect(preparedParams).to.deep.equal({
+      tags: [['custom=annotation1', 'custom=annotation2']],
+    });
+  });
+
+  it('correctly prepares search parameters with an <or> and <and> annotation', () => {
+    const preparedParams = prepareSearchParameters({
+      annotations: [['annotation1', 'annotation2'], 'annotation3'],
+    });
+    expect(preparedParams).to.deep.equal({
+      tags: [['custom=annotation1', 'custom=annotation2'], 'custom=annotation3'],
+    });
+  });
+
+  it('correctly prepares search parameters with an <or> annotation and fallbacks', () => {
+    const preparedParams = prepareSearchParameters({
+      annotations: [['annotation1', '***it was: agatha all along***']],
+    });
+    expect(preparedParams).to.deep.equal({
+      tags: [
+        [
+          'custom=annotation1',
+          'custom=%2a%2a%2ait%20was%3a%20agatha%20all%20along%2a%2a%2a',
+          'custom=%2a%2a%2ait%20was%3A%20agatha%20all%20along%2a%2a%2a',
+          'custom=***it was: agatha all along***',
+          'custom=%2A%2A%2Ait%20was%3A%20agatha%20all%20along%2A%2A%2A',
+        ],
+      ],
+    });
+  });
+
+  it('correctly prepares search parameters with an <or> annotation, exclude_tags and fallbacks', () => {
+    const preparedParams = prepareSearchParameters({
+      annotations: [['annotation1', '***it was: agatha all along***']],
+      exclude_tags: ['***it was: agatha all along***'],
+    });
+    expect(preparedParams).to.deep.equal({
+      tags: [
+        [
+          'custom=annotation1',
+          'custom=%2a%2a%2ait%20was%3a%20agatha%20all%20along%2a%2a%2a',
+          'custom=%2a%2a%2ait%20was%3A%20agatha%20all%20along%2a%2a%2a',
+          'custom=***it was: agatha all along***',
+          'custom=%2A%2A%2Ait%20was%3A%20agatha%20all%20along%2A%2A%2A',
+        ],
+      ],
+      exclude_tags: [
+        [
+          'custom=%2a%2a%2ait%20was%3a%20agatha%20all%20along%2a%2a%2a',
+          'custom=%2a%2a%2ait%20was%3A%20agatha%20all%20along%2a%2a%2a',
+          'custom=***it was: agatha all along***',
+          'custom=%2A%2A%2Ait%20was%3A%20agatha%20all%20along%2A%2A%2A',
+        ],
+      ],
+    });
+  });
+
   it('throws when an unsupported parameter is passed', () => {
     expect(() =>
       prepareSearchParameters({ illegalTag: 'suchIllegalMuchEvil' } as Params)

--- a/test/services/recordServiceTest.ts
+++ b/test/services/recordServiceTest.ts
@@ -437,6 +437,31 @@ describe('services/recordService', () => {
         .catch(done);
     });
 
+    it('works as expected when there is a tag group and a tag', done => {
+      const params = {
+        tags: [[testVariables.tag, testVariables.secondTag], testVariables.secondTag],
+      };
+      const expectedParamsForRoute = {
+        exclude_tags: [],
+        tags: [
+          `(${testVariables.encryptedTag},${testVariables.encryptedSecondTag})`,
+          testVariables.encryptedSecondTag,
+        ],
+      };
+      recordService
+        .searchRecords(testVariables.userId, params)
+        .then(res => {
+          expect(res.records.length).to.equal(1);
+          expect(res.totalCount).to.equal(recordResources.count);
+          expect(res.records[0].id).to.equal(testVariables.recordId);
+          expect(searchRecordsStub).to.be.calledOnce;
+          expect(searchRecordsStub).to.be.calledWith(testVariables.userId, expectedParamsForRoute);
+          expect(getUserStub).to.be.calledOnce;
+          done();
+        })
+        .catch(done);
+    });
+
     it('works as expected when there is an excluded tag group', done => {
       const params = {
         exclude_tags: [[testVariables.tag, testVariables.secondTag]],


### PR DESCRIPTION
### Summary of the issue

The backend supports AND gating and OR grouping:
> Multiple tags can be separated by comma for AND gating. Tags can be grouped together using round brackets for creating groups of OR conditions.

Even though the SDK (internally) already supported this, this PR exposes this feature to the enduser. OR groups can now be created by adding the annotations to an array:
```
{
  ...
  annotations: [['tag1, 'tag2'], 'tag3'],
  ...
}
```
Using these annotations in a query, the result will include resources that are tagged with `tag1` OR `tag2` AND `tag3`.

For `exclude_tags` the logic is reversed.

### Due diligence checklist
- [x] Updated version in package.json if applicable.
- [x] Added/updated tests.
- [x] Add documentation
- [x] If this change affects SDK consumers: communicate changes.

