### PR TITLE
✨ Allow disabling of user info polling

### DIFF
--- a/docs/sdk.md
+++ b/docs/sdk.md
@@ -30,8 +30,9 @@ To revoke the received refresh token, post to '/oauth/revoke' with the refresh t
         environment,            // The environment the SDK should run in. The options are 'development' and 'production'
         privateKey,             // Private key of the logged-in user
         requestAccessToken,     // Callback for requesting a valid access token
-        extendedEnvConfig,     // additional environment configuration options
-        fhirVersion
+        extendedEnvConfig,      // Additional environment configuration options
+        fhirVersion,            // The FHIR version to use (3.0.1 or 4.0.1), defaults to '3.0.1'
+        disableUserPolling      // Disabled user info polling (e.g for common key updates) if it is not required, defaults to `false`
         });
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@d4l/js-sdk",
-  "version": "5.10.0",
+  "version": "5.11.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@d4l/js-sdk",
-      "version": "5.10.0",
+      "version": "5.11.0",
       "hasInstallScript": true,
       "license": "See license in LICENSE",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@d4l/js-sdk",
-  "version": "5.10.0",
+  "version": "5.11.0",
   "D4L": {
     "data_model_version": 1
   },


### PR DESCRIPTION
### Summary of the issue

With this change it is possible to disable the regular (every 5min) polling of updates in the common keys. The default is to keep it enabled.

https://gesundheitscloud.atlassian.net/browse/HUB-2518

### Due diligence checklist
- [x] Updated version in package.json if applicable.
- [ ] Added/updated tests.
- [x] Add documentation
- [ ] If this change affects SDK consumers: communicate changes.

