### PR TITLE
♻️  HUB-2809 CIT-4600 CIT-4601 Use new key management service endpoints

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@d4l/js-sdk",
-  "version": "5.12.0",
+  "version": "6.0.0-beta.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@d4l/js-sdk",
-      "version": "5.12.0",
+      "version": "6.0.0-beta.0",
       "hasInstallScript": true,
       "license": "See license in LICENSE",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@d4l/js-sdk",
-  "version": "5.12.0",
+  "version": "6.0.0-beta.0",
   "D4L": {
     "data_model_version": 1
   },

--- a/src/routes/keyRoutes.ts
+++ b/src/routes/keyRoutes.ts
@@ -1,0 +1,34 @@
+import config from '../config/index';
+import d4lRequest from '../lib/d4lRequest';
+
+const keyRoutes = {
+  /**
+   * Get the application specific common and public keys for the current app for a specific user
+   * @param userId The id of the user to get the keys for
+   * @returns All common keys and the public key belonging to the user
+   */
+  async getUserKeys(
+    userId: string
+  ): Promise<{
+    common_keys: {
+      active_common_key_id: string;
+      app_id: string;
+      common_keys: { common_key_id: string; common_key: string }[];
+      tag_encryption_key: string;
+    };
+    public_key: {
+      id: string;
+      pubkey: string;
+    };
+  }> {
+    return d4lRequest.submit(
+      'GET',
+      `${config.apiUrl()}/keys/api/v1/keys/users/${userId}/current-app`,
+      {
+        authorize: true,
+      }
+    );
+  },
+};
+
+export default keyRoutes;

--- a/src/routes/userRoutes.ts
+++ b/src/routes/userRoutes.ts
@@ -36,12 +36,6 @@ const userRoutes = {
     });
   },
 
-  getCommonKey(userId: string, commonKeyId: string) {
-    return d4lRequest.submit('GET', `${config.userUrl(userId)}/commonkeys/${commonKeyId}`, {
-      authorize: true,
-    });
-  },
-
   getCAPs(appId: string) {
     return d4lRequest.submit('GET', `${config.apiUrl()}/permissions`, {
       authorize: true,

--- a/src/services/userService.ts
+++ b/src/services/userService.ts
@@ -193,9 +193,12 @@ const userService = {
       // the method multiple times in a short period with the same arguments,
       // only one endpoint call will be made.
       // TODO: Terra often makes multiple calls to the same endpoint. Is a similar issue to blame?
-      this.commonKeys[userId][keyId] = await userRoutes
-        .getCommonKey(userId, keyId)
-        .then(res => asymDecryptString(this.privateKey, res.common_key))
+      this.commonKeys[userId][keyId] = await keyRoutes
+        .getUserKeys(userId)
+        .then(({ common_keys }) => {
+          const matchingKey = common_keys.common_keys.find(key => key.common_key_id === keyId);
+          return asymDecryptString(this.privateKey, matchingKey.common_key);
+        })
         .then(JSON.parse);
     }
     return this.commonKeys[userId][keyId];

--- a/test/routes/keyRoutesTest.ts
+++ b/test/routes/keyRoutesTest.ts
@@ -1,0 +1,48 @@
+/* eslint-env mocha */
+/* eslint-disable no-unused-expressions */
+/* eslint-disable max-nested-callbacks */
+import config from '../../src/config/index';
+import 'babel-polyfill';
+import chai from 'chai';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+import keyRoutes from '../../src/routes/keyRoutes';
+import d4lRequest from '../../src/lib/d4lRequest';
+import testVariables from '../testUtils/testVariables';
+
+chai.use(sinonChai);
+
+const { expect } = chai;
+
+describe('userRoutes', () => {
+  let requestStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    requestStub = sinon.stub(d4lRequest, 'submit');
+  });
+
+  afterEach(() => {
+    requestStub.restore();
+  });
+
+  it('getUserKeys passes', done => {
+    requestStub
+      .withArgs(
+        'GET',
+        // @ts-ignore
+        `${config.environmentConfig.api}/keys/api/v1/keys/users/${testVariables.userId}/current-app`,
+        {
+          authorize: true,
+        }
+      )
+      .returns(Promise.resolve('pass'));
+
+    keyRoutes.getUserKeys(testVariables.userId).then(res => {
+      expect(res).to.equal('pass');
+      expect(requestStub).to.be.calledOnce;
+      expect(requestStub.firstCall.args[2].authorize).to.equal(true);
+      expect(requestStub).to.be.calledWith('GET');
+      done();
+    });
+  });
+});

--- a/test/services/userServiceTest.ts
+++ b/test/services/userServiceTest.ts
@@ -143,7 +143,6 @@ describe('services/userService', () => {
       userService
         .getCommonKey(testVariables.userId, testVariables.commonKeyId)
         .then(key => {
-          // TODO !!
           expect(getUserKeysStub).to.be.calledOnce;
           expect(getUserKeysStub).to.be.calledWith(testVariables.userId);
           expect(key).to.deep.equal(encryptionResources.commonKey);

--- a/test/services/userServiceTest.ts
+++ b/test/services/userServiceTest.ts
@@ -9,30 +9,38 @@ import sinonChai from 'sinon-chai';
 
 import userService from '../../src/services/userService';
 import userRoutes from '../../src/routes/userRoutes';
+import keyRoutes from '../../src/routes/keyRoutes';
 import { NOT_SETUP } from '../../src/lib/errors/SetupError';
 import testVariables from '../testUtils/testVariables';
 import userResources from '../testUtils/userResources';
 import encryptionResources from '../testUtils/encryptionResources';
+import keyResources from '../testUtils/keyResources';
 
 chai.use(sinonChai);
 
 const { expect } = chai;
 
 describe('services/userService', () => {
+  // User routes
   let getCommonKeyStub;
   let fetchUserInfoStub;
   let getReceivedPermissionsStub;
   let getCAPsStub;
   let grantPermissionStub;
 
+  // Key routes
+  let getUserKeysStub;
+
   beforeEach(() => {
-    // USERROUTES
+    // User routes
     fetchUserInfoStub = sinon
       .stub(userRoutes, 'fetchUserInfo')
       .returns(Promise.resolve(userResources.userInfo));
-    getCommonKeyStub = sinon
-      .stub(userRoutes, 'getCommonKey')
-      .returns(Promise.resolve({ common_key: encryptionResources.encryptedCommonKey }));
+    getCommonKeyStub = sinon.stub(userRoutes, 'getCommonKey').returns(
+      Promise.resolve({
+        common_key: encryptionResources.encryptedCommonKey,
+      })
+    );
     getReceivedPermissionsStub = sinon
       .stub(userRoutes, 'getReceivedPermissions')
       .returns(Promise.resolve([encryptionResources.permissionResponse]));
@@ -41,17 +49,25 @@ describe('services/userService', () => {
       .stub(userRoutes, 'getCAPs')
       .returns(Promise.resolve([encryptionResources.permissionResponse]));
 
+    // Key routes
+    getUserKeysStub = sinon
+      .stub(keyRoutes, 'getUserKeys')
+      .returns(Promise.resolve(keyResources.getUserKeys));
+
     userService.setPrivateKey(encryptionResources.CUPPrivateKey);
   });
 
   afterEach(() => {
     userService.resetUser();
-    // USERROUTES
+    // User routes
     fetchUserInfoStub.restore();
     getCommonKeyStub.restore();
     getReceivedPermissionsStub.restore();
     grantPermissionStub.restore();
     getCAPsStub.restore();
+
+    // Key routes
+    getUserKeysStub.restore();
   });
 
   describe('pullUser', () => {

--- a/test/services/userServiceTest.ts
+++ b/test/services/userServiceTest.ts
@@ -22,25 +22,19 @@ const { expect } = chai;
 
 describe('services/userService', () => {
   // User routes
-  let getCommonKeyStub;
   let fetchUserInfoStub;
   let getReceivedPermissionsStub;
   let getCAPsStub;
   let grantPermissionStub;
 
   // Key routes
-  let getUserKeysStub;
+  let getUserKeysStub: sinon.SinonStub;
 
   beforeEach(() => {
     // User routes
     fetchUserInfoStub = sinon
       .stub(userRoutes, 'fetchUserInfo')
       .returns(Promise.resolve(userResources.userInfo));
-    getCommonKeyStub = sinon.stub(userRoutes, 'getCommonKey').returns(
-      Promise.resolve({
-        common_key: encryptionResources.encryptedCommonKey,
-      })
-    );
     getReceivedPermissionsStub = sinon
       .stub(userRoutes, 'getReceivedPermissions')
       .returns(Promise.resolve([encryptionResources.permissionResponse]));
@@ -61,7 +55,6 @@ describe('services/userService', () => {
     userService.resetUser();
     // User routes
     fetchUserInfoStub.restore();
-    getCommonKeyStub.restore();
     getReceivedPermissionsStub.restore();
     grantPermissionStub.restore();
     getCAPsStub.restore();
@@ -123,14 +116,16 @@ describe('services/userService', () => {
     });
   });
 
-  // @ts-ignore
-  describe('isCurrentUser', done => {
-    it('Happy Path', () => {
-      userService.pullUser().then(() => {
-        const isCurrentUser = userService.isCurrentUser(testVariables.userId);
-        expect(isCurrentUser).to.equal(true);
-        done();
-      });
+  describe('isCurrentUser', () => {
+    it('Happy Path', done => {
+      userService
+        .pullUser()
+        .then(() => {
+          const isCurrentUser = userService.isCurrentUser(testVariables.userId);
+          expect(isCurrentUser).to.equal(true);
+          done();
+        })
+        .catch(done);
     });
   });
 
@@ -148,11 +143,9 @@ describe('services/userService', () => {
       userService
         .getCommonKey(testVariables.userId, testVariables.commonKeyId)
         .then(key => {
-          expect(getCommonKeyStub).to.be.calledOnce;
-          expect(getCommonKeyStub).to.be.calledWith(
-            testVariables.userId,
-            testVariables.commonKeyId
-          );
+          // TODO !!
+          expect(getUserKeysStub).to.be.calledOnce;
+          expect(getUserKeysStub).to.be.calledWith(testVariables.userId);
           expect(key).to.deep.equal(encryptionResources.commonKey);
           done();
         })
@@ -167,7 +160,7 @@ describe('services/userService', () => {
         .getCommonKey(testVariables.userId, testVariables.commonKeyId)
         .then(key => {
           expect(key).to.equal(fakeCommonKey);
-          expect(getCommonKeyStub).to.not.be.called;
+          expect(getUserKeysStub).to.not.be.called;
           done();
         })
         .catch(done);

--- a/test/testUtils/keyResources.ts
+++ b/test/testUtils/keyResources.ts
@@ -1,0 +1,24 @@
+import testVariables from './testVariables';
+import encryptionResources from './encryptionResources';
+
+const keyResources = {
+  getUserKeys: {
+    common_keys: {
+      active_common_key_id: testVariables.commonKeyId,
+      app_id: testVariables.appId,
+      common_keys: [
+        {
+          common_key_id: testVariables.commonKeyId,
+          common_key: encryptionResources.encryptedCommonKey,
+        },
+      ],
+      tag_encryption_key: encryptionResources.encryptedTagEncryptionKey,
+    },
+    public_key: {
+      id: 'CURRENTLY NOT USED',
+      pubkey: 'CURRENTLY NOT USED',
+    },
+  },
+};
+
+export default keyResources;


### PR DESCRIPTION
### Summary of the issue

The key management is being moved to a separate service and therefore we need to migrated to the new endpoints.

### How to test the refactoring

1. Run `npm run build`
2. Switch directory to `/dest`
3. Run `npm link`
4. Switch to the project which uses the JS-SDK
5. Use the linked version of the JS-SDK by running `npm link @d4l/js-sdk`
6. Run and test your project

### Due diligence checklist
- [x] Updated version in package.json if applicable.
- [x] Added/updated tests.
- [x] Add documentation
- [x] If this change affects SDK consumers: communicate changes.


### TODOs
- [ ] Ensure that all consumers of this SDK have tested the changes
